### PR TITLE
feat: API 格式四檔切換（openai_compat / openai_responses / claude_messages / gemini_interactions），參照 TauriTavern

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,8 @@ import {
 import {
   createEmptyChatState,
   DEFAULT_SYSTEM_PROMPT,
+  getApiUrlForFormat,
+  normalizeApiFormat,
   getCharacterWorldBookName,
   getCharacterWorldBookNameViaSTscript,
   getActiveGlobalWorldBookNames,
@@ -5275,6 +5277,19 @@ function getLastPagerView() {
   return 'home';
 }
 
+function updateApiEndpointPreview() {
+  try {
+    const baseInput = document.getElementById('bs-bt-api-url');
+    const formatInput = document.getElementById('bs-bt-api-format');
+    const previewCode = document.getElementById('bs-bt-api-endpoint-preview-code');
+    if (!previewCode) return;
+    const rawBase = String(baseInput?.value || '').trim();
+    const fmt = normalizeApiFormat(formatInput?.value);
+    const base = rawBase.replace(/\/+$/, '').replace(/\/(chat\/completions|models|responses|messages|interactions)$/i, '').replace(/\/+$/, '') || '<Base URL>';
+    previewCode.textContent = getApiUrlForFormat(base, fmt);
+  } catch {}
+}
+
 function applySettingsToForm(ctx) {
   const settings = getSettings(ctx);
   syncRacePhysiologyOverrides(settings);
@@ -5287,8 +5302,10 @@ function applySettingsToForm(ctx) {
   setValue('bs-bt-enabled', settings.enabled);
   setValue('bs-bt-tracker-preset-list', settings.useStPresetForAsync ? CURRENT_PRESET_OPTION_VALUE : (settings.trackerPresetName || NO_PRESET_OPTION_VALUE));
   setValue('bs-bt-api-url', settings.apiUrl);
+  setValue('bs-bt-api-format', normalizeApiFormat(settings.apiFormat));
   setValue('bs-bt-api-key', settings.apiKey);
   setValue('bs-bt-model', settings.model);
+  updateApiEndpointPreview();
   setValue('bs-bt-formatted-output-v4', settings.formattedOutputV4 !== false);
   setValue('bs-bt-mvu-extra-analysis-compat', settings.mvuExtraAnalysisCompat !== false);
   setValue('bs-bt-race-catalog', settings.raceCatalogInPrompt !== false);
@@ -5866,6 +5883,7 @@ function readSettingsFromForm(ctx) {
     settings.trackerPresetName = normalizeTrackerPresetSelectionValue(trackerPresetSelectionValue);
   }
   settings.apiUrl = String(getValue('bs-bt-api-url')).trim();
+  settings.apiFormat = normalizeApiFormat(getValue('bs-bt-api-format'));
   settings.apiKey = String(getValue('bs-bt-api-key')).trim();
   settings.model = String(getValue('bs-bt-model')).trim();
   const formattedOutputToggle = document.getElementById('bs-bt-formatted-output-v4');
@@ -6466,6 +6484,16 @@ async function ensureModal(ctx) {
     if (!nextModel) return;
     const modelInput = document.getElementById('bs-bt-model');
     if (modelInput) modelInput.value = nextModel;
+  });
+  document.addEventListener('input', (event) => {
+    if (event.target?.id === 'bs-bt-api-url') updateApiEndpointPreview();
+  });
+  document.addEventListener('change', (event) => {
+    if (event.target?.id === 'bs-bt-api-format') {
+      updateApiEndpointPreview();
+      try { readSettingsFromForm(ctx); saveSettings(ctx); } catch {}
+      console.log('[BS BioTracker] apiFormat changed ->', normalizeApiFormat(event.target?.value));
+    }
   });
   document.getElementById('bs-bt-tracker-preset-list')?.addEventListener('change', async () => {
     readSettingsFromForm(ctx);

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,8 +1,9 @@
-import { DEFAULT_SYSTEM_PROMPT } from './state.js';
+import { API_FORMATS, DEFAULT_SYSTEM_PROMPT, getApiUrlForFormat, normalizeApiFormat } from './state.js';
 import {
   getHostChat,
   getHostChatCompletionSettings,
   getHostContext,
+  getHostKind,
   getHostPreset,
   getHostPresetManager,
   getHostWorldInfoPrompt,
@@ -74,14 +75,61 @@ function buildFormattedOutputV4Instruction() {
 
 export function getApiBase(settings) {
   let apiBase = String(settings.apiUrl || '').trim().replace(/\/+$/, '');
-  apiBase = apiBase.replace(/\/(chat\/completions|models)$/i, '');
+  apiBase = apiBase.replace(/\/(chat\/completions|models|responses|messages|interactions)$/i, '');
   return apiBase.replace(/\/+$/, '');
 }
 
 export function getAuthHeaders(settings) {
   const headers = { 'Content-Type': 'application/json' };
-  if (settings.apiKey) headers.Authorization = `Bearer ${settings.apiKey}`;
+  const key = settings.apiKey ? String(settings.apiKey) : '';
+  const format = normalizeApiFormat(settings?.apiFormat);
+  if (format === API_FORMATS.CLAUDE_MESSAGES) {
+    if (!headers['anthropic-version']) headers['anthropic-version'] = '2023-06-01';
+    if (key) {
+      headers.Authorization = `Bearer ${key}`;
+      headers['x-api-key'] = key;
+    }
+  } else if (format === API_FORMATS.GEMINI_INTERACTIONS) {
+    // Google AI 认证走 x-goog-api-key（TauriTavern apply_gemini_auth 同规则）
+    if (key) headers['x-goog-api-key'] = key;
+  } else if (key) {
+    headers.Authorization = `Bearer ${key}`;
+  }
   return headers;
+}
+
+export function getApiFormatPreview(settings) {
+  const apiBase = getApiBase(settings) || '<Base URL>';
+  return getApiUrlForFormat(apiBase, settings?.apiFormat);
+}
+
+/**
+ * 宿主代理对非 OpenAI 兼容格式的支持：
+ * TauriTavern 后端读取 payload.custom_api_format，按 openai_responses.rs / claude
+ * builder 在服务端翻译 messages → /responses | /messages 上游请求；
+ * 原版 SillyTavern 后端不理解 custom_api_format，非 compat 格式改走 /proxy/ 透传
+ * 或浏览器直连（见 postBody 的传输选择）。
+ */
+function hostSupportsFormatAwareProxy() {
+  try {
+    return getHostKind() === 'tauritavern';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 把最近一次真实请求打到 UI（连接状态栏），TT 桌面端没有控制台也能看到端点与状态码。
+ */
+function traceRequestToUi(method, url, status, transport = '') {
+  if (typeof document === 'undefined') return;
+  try {
+    const node = document.getElementById('bs-bt-connect-status');
+    if (!node) return;
+    const suffix = status ? ` → HTTP ${status}` : '';
+    const via = transport ? `（${transport}）` : '';
+    node.textContent = `最近请求：${method} ${url}${suffix}${via}`;
+  } catch {}
 }
 
 function isBrowserRuntime() {
@@ -118,12 +166,28 @@ function getHostProxyHeaders(extraHeaders = {}) {
 
 function buildHostProxyConfig(apiBase, settings) {
   const apiKey = String(settings?.apiKey || '');
+  const format = normalizeApiFormat(settings?.apiFormat);
+  let customIncludeHeaders = '';
+  if (apiKey) {
+    if (format === API_FORMATS.GEMINI_INTERACTIONS) {
+      // Google AI 认 x-goog-api-key；Authorization: Bearer 会被当成 OAuth 而 401
+      customIncludeHeaders = `x-goog-api-key: ${apiKey}`;
+    } else if (format === API_FORMATS.CLAUDE_MESSAGES) {
+      customIncludeHeaders = [
+        `Authorization: Bearer ${apiKey}`,
+        `x-api-key: ${apiKey}`,
+        'anthropic-version: 2023-06-01',
+      ].join('\n');
+    } else {
+      customIncludeHeaders = `Authorization: Bearer ${apiKey}`;
+    }
+  }
   return {
     chat_completion_source: 'custom',
     custom_url: apiBase,
     reverse_proxy: apiBase,
     proxy_password: apiKey,
-    custom_include_headers: apiKey ? `Authorization: Bearer ${apiKey}` : '',
+    custom_include_headers: customIncludeHeaders,
   };
 }
 
@@ -349,7 +413,8 @@ async function requestHostProxyModelList(apiBase, settings) {
   });
 }
 
-async function requestHostProxyChatCompletion(apiBase, settings, requestBody, runContext = {}) {
+async function requestHostProxyChatCompletion(apiBase, settings, requestBody, runContext = {}, apiFormat = API_FORMATS.OPENAI_COMPAT) {
+  const formatAware = apiFormat && apiFormat !== API_FORMATS.OPENAI_COMPAT;
   const proxyBody = {
     messages: requestBody.messages,
     model: requestBody.model,
@@ -360,7 +425,8 @@ async function requestHostProxyChatCompletion(apiBase, settings, requestBody, ru
     presence_penalty: requestBody.presence_penalty,
     max_tokens: requestBody.max_tokens,
     seed: requestBody.seed,
-    response_format: requestBody.response_format,
+    // 非 compat 格式交给宿主后端按 custom_api_format 翻译；response_format 不在其中
+    ...(formatAware ? { custom_api_format: apiFormat } : { response_format: requestBody.response_format }),
     stream: false,
     ...buildHostProxyConfig(apiBase, settings),
   };
@@ -760,11 +826,189 @@ function buildPresetSamplingBodyFromPreset(preset) {
   return body;
 }
 
+function buildResponsesInput(messages) {
+  return (Array.isArray(messages) ? messages : []).map((m) => {
+    const role = String(m?.role || 'user').toLowerCase();
+    const content = String(m?.content ?? '');
+    if (role === 'system') return { role: 'developer', content };
+    if (role === 'developer') return { role: 'developer', content };
+    if (role === 'assistant') return { role: 'assistant', content };
+    return { role: 'user', content };
+  });
+}
+
+function extractResponsesText(data) {
+  if (!data || typeof data !== 'object') return '';
+  if (typeof data.output_text === 'string' && data.output_text.trim()) return data.output_text;
+  const output = Array.isArray(data.output) ? data.output : [];
+  for (const item of output) {
+    if (!item || typeof item !== 'object') continue;
+    if (item.type === 'message' && item.role === 'assistant') {
+      const content = Array.isArray(item.content) ? item.content : [];
+      for (const part of content) {
+        if (part?.type === 'output_text' && typeof part.text === 'string') return part.text;
+        if (typeof part?.text === 'string') return part.text;
+      }
+    }
+  }
+  if (typeof data?.choices?.[0]?.message?.content === 'string') return data.choices[0].message.content;
+  return '';
+}
+
+function buildClaudeMessagesBody(body) {
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  let system = '';
+  const claudeMessages = [];
+  for (const m of messages) {
+    const role = String(m?.role || '').toLowerCase();
+    const content = String(m?.content ?? '');
+    if (role === 'system') {
+      system = system ? `${system}\n\n${content}` : content;
+    } else if (role === 'assistant') {
+      claudeMessages.push({ role: 'assistant', content });
+    } else {
+      claudeMessages.push({ role: 'user', content });
+    }
+  }
+  const out = {
+    model: body.model,
+    max_tokens: body.max_tokens || body.max_completion_tokens || 4096,
+    messages: claudeMessages,
+  };
+  if (system) out.system = system;
+  if (body.temperature !== undefined) out.temperature = body.temperature;
+  if (body.top_p !== undefined) out.top_p = body.top_p;
+  if (body.top_k !== undefined) out.top_k = body.top_k;
+  return out;
+}
+
+function extractClaudeText(data) {
+  if (!data || typeof data !== 'object') return '';
+  if (typeof data?.content === 'string') return data.content;
+  const content = Array.isArray(data.content) ? data.content : [];
+  for (const part of content) {
+    if (part?.type === 'text' && typeof part.text === 'string') return part.text;
+    if (typeof part?.text === 'string') return part.text;
+  }
+  if (typeof data?.choices?.[0]?.message?.content === 'string') return data.choices[0].message.content;
+  return '';
+}
+
+function normalizeResponsesData(data) {
+  const text = extractResponsesText(data);
+  return { choices: [{ message: { content: text } }] };
+}
+
+function normalizeClaudeData(data) {
+  const text = extractClaudeText(data);
+  return { choices: [{ message: { content: text } }] };
+}
+
+/**
+ * Gemini Interactions API 请求体（参照 TauriTavern gemini_interactions.rs）：
+ * messages → steps（user_input / model_output + text block），system 合并为
+ * system_instruction，采样参数进 generation_config。插件只发纯文本，不涉及
+ * tool / 媒体 block；response_format 仅在有 json_schema 时才会出现，这里省略。
+ */
+function buildGeminiInteractionsBody(body) {
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const systemParts = [];
+  const steps = [];
+  for (const m of messages) {
+    const role = String(m?.role || '').toLowerCase();
+    const text = String(m?.content ?? '');
+    if (role === 'system' || role === 'developer') {
+      if (text.trim()) systemParts.push(text.trim());
+    } else if (role === 'assistant') {
+      if (text.trim()) steps.push({ type: 'model_output', content: [{ type: 'text', text }] });
+    } else {
+      steps.push({ type: 'user_input', content: [{ type: 'text', text }] });
+    }
+  }
+  const request = {
+    model: body.model,
+    input: steps,
+    stream: false,
+    store: false,
+  };
+  if (systemParts.length) request.system_instruction = systemParts.join('\n\n');
+  const generationConfig = {};
+  if (Number.isFinite(body.temperature)) generationConfig.temperature = body.temperature;
+  if (Number.isFinite(body.top_p)) generationConfig.top_p = body.top_p;
+  if (Number.isFinite(body.top_k) && body.top_k > 0) generationConfig.top_k = Math.floor(body.top_k);
+  const maxTokens = Number.isFinite(body.max_tokens) ? body.max_tokens : body.max_completion_tokens;
+  if (Number.isFinite(maxTokens) && maxTokens > 0) generationConfig.max_output_tokens = Math.floor(maxTokens);
+  if (Object.keys(generationConfig).length) request.generation_config = generationConfig;
+  return request;
+}
+
+/**
+ * 非流式 Interactions 回覆。
+ * 直连 / ST /proxy 拿到原生 {status, steps}；TT 格式感知代理会先正规化成
+ * OpenAI {choices:[{message:{content}}]}（见 normalize_gemini_interactions_response），
+ * 那种回包没有 steps，必须走 choices 回退，否则内容会被读成空字符串。
+ */
+function extractGeminiInteractionsText(data) {
+  if (!data || typeof data !== 'object') return '';
+  if (typeof data?.choices?.[0]?.message?.content === 'string') {
+    return data.choices[0].message.content;
+  }
+  const status = String(data.status || '');
+  if (status === 'failed') {
+    throw new Error(`Gemini Interactions 回传失败：${String(data?.error?.message || 'unknown error')}`);
+  }
+  if (status && status !== 'completed' && status !== 'requires_action' && status !== 'incomplete') {
+    throw new Error(`Gemini Interactions 未正常完成（status: ${status}）`);
+  }
+  const steps = Array.isArray(data.steps) ? data.steps : [];
+  let text = '';
+  for (const step of steps) {
+    if (step?.type !== 'model_output') continue;
+    const content = Array.isArray(step.content) ? step.content : [];
+    for (const block of content) {
+      if (block?.type === 'text' && typeof block.text === 'string') text += block.text;
+    }
+  }
+  if (!text) {
+    throw new Error(`Gemini Interactions 回覆没有可消费的文本（status: ${status || 'unknown'}）`);
+  }
+  return text;
+}
+
+function normalizeGeminiInteractionsData(data) {
+  return { choices: [{ message: { content: extractGeminiInteractionsText(data) } }] };
+}
+
+/** 直连时按格式转换请求体；宿主代理走格式感知翻译时用不到（后端自己转）。 */
+function buildDirectPayload(fmt, requestBody) {
+  if (fmt === API_FORMATS.OPENAI_RESPONSES) {
+    const input = buildResponsesInput(requestBody.messages);
+    const payload = {
+      model: requestBody.model,
+      input,
+      store: false,
+      temperature: requestBody.temperature,
+      top_p: requestBody.top_p,
+      seed: requestBody.seed,
+    };
+    if (requestBody.max_tokens) payload.max_output_tokens = requestBody.max_tokens;
+    if (requestBody.max_completion_tokens) payload.max_output_tokens = requestBody.max_completion_tokens;
+    if (requestBody.response_format?.type === 'json_object') {
+      payload.text = { format: { type: 'json_object' } };
+    }
+    return payload;
+  }
+  if (fmt === API_FORMATS.CLAUDE_MESSAGES) {
+    return buildClaudeMessagesBody(requestBody);
+  }
+  if (fmt === API_FORMATS.GEMINI_INTERACTIONS) {
+    return buildGeminiInteractionsBody(requestBody);
+  }
+  return requestBody;
+}
+
 async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
   const logApiDebug = (phase, details = {}) => {
-    // 默认关闭：完整 request/response 含聊天内容，同页任何脚本（其他扩展、角色卡的
-    // TH 脚本经 window.parent）都读得到。排查时在控制台执行：
-    //   globalThis.__bs_biotracker_debug_api__ = true
     if (!globalThis.__bs_biotracker_debug_api__) return;
     try {
       const label = `[BS BioTracker][API debug] ${phase}`;
@@ -778,40 +1022,80 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
   const postBody = async (requestBody, attempt = 'primary') => {
     const previousAsyncFlag = globalThis.__bs_biotracker_async_request__;
     globalThis.__bs_biotracker_async_request__ = true;
-    const url = `${apiBase}/chat/completions`;
-    // 代理路径同样把 key 交给 ST 后端转发，所以无条件校验，不只校验直连
+    const fmt = normalizeApiFormat(settings?.apiFormat);
+    const upstreamUrl = getApiUrlForFormat(apiBase, fmt);
+    const isCompat = fmt === API_FORMATS.OPENAI_COMPAT;
+    // TT 后端按 custom_api_format 在服务端翻译；原版 ST 后端不认得这个字段
+    const formatAwareProxy = !isCompat && hostSupportsFormatAwareProxy();
+    // ST/Luker 的 /proxy/<url> 透传代理：服务端原样转发绕开 CORS（需 config.yaml 开启 enableCorsProxy，未开启返回 404）
+    const transparentProxyUrl = !isCompat && !formatAwareProxy && isBrowserRuntime() && isCrossOriginUrl(upstreamUrl)
+      ? `/proxy/${upstreamUrl}`
+      : null;
+    const canUseHostProxy = shouldUseHostProxy(upstreamUrl) && (isCompat || formatAwareProxy);
+    let transport = canUseHostProxy
+      ? (formatAwareProxy ? 'host-proxy-formatted' : 'host-proxy')
+      : (transparentProxyUrl ? 'host-proxy-transparent' : 'direct');
+    let url = canUseHostProxy ? '/api/backends/chat-completions/generate' : (transparentProxyUrl || upstreamUrl);
+    const payloadForTransport = canUseHostProxy ? requestBody : buildDirectPayload(fmt, requestBody);
     assertSafeDirectApiBase(apiBase);
-    const useHostProxy = shouldUseHostProxy(url);
-    let transport = useHostProxy ? 'host-proxy' : 'direct';
     let requestText = '';
     try {
-      requestText = JSON.stringify(requestBody);
+      requestText = JSON.stringify(payloadForTransport);
       logApiDebug(`request:${attempt}`, {
         transport,
-        url: useHostProxy ? '/api/backends/chat-completions/generate' : url,
+        url,
         apiBase,
-        requestBody,
+        format: fmt,
+        requestBody: payloadForTransport,
         requestText,
         requestTextLength: requestText.length,
       });
       let response;
       let responseText;
-      if (useHostProxy) {
+      if (canUseHostProxy) {
         let proxyError = null;
         try {
-          ({ response, responseText } = await requestHostProxyChatCompletion(apiBase, settings, requestBody, runContext));
+          ({ response, responseText } = await requestHostProxyChatCompletion(apiBase, settings, requestBody, runContext, fmt));
         } catch (error) {
           proxyError = error;
           logApiDebug(`proxy_error:${attempt}`, { proxyError: error });
-          // 代理已经等满超时（或整轮时限已到），直连只会再卡一次同样的时长
           if (isApiTimeoutError(error) || isApiDeadlineError(error)) throw error;
         }
         if (proxyError || (!response.ok && shouldFallbackFromHostProxy(responseText, response.status))) {
           transport = proxyError ? 'direct-after-proxy-error' : `direct-after-proxy-${response.status}`;
+          url = upstreamUrl;
           if (!proxyError && (response.status === 401 || response.status === 403)) {
             disableHostProxyForSession(response.status, responseText);
           }
-          ({ response, responseText } = await fetchText(url, {
+          ({ response, responseText } = await fetchText(upstreamUrl, {
+            method: 'POST',
+            headers: getAuthHeaders(settings),
+            body: requestText,
+            timeoutMs: resolveApiTimeoutMs(settings),
+            externalSignal: runContext.signal || null,
+            deadlineMs: runContext.deadlineMs || 0,
+          }));
+        }
+      } else if (transparentProxyUrl) {
+        let proxyError = null;
+        try {
+          ({ response, responseText } = await fetchText(transparentProxyUrl, {
+            method: 'POST',
+            headers: getHostProxyHeaders(getAuthHeaders(settings)),
+            body: requestText,
+            timeoutMs: resolveApiTimeoutMs(settings),
+            externalSignal: runContext.signal || null,
+            deadlineMs: runContext.deadlineMs || 0,
+          }));
+        } catch (error) {
+          proxyError = error;
+          logApiDebug(`transparent_proxy_error:${attempt}`, { proxyError: error });
+          if (isApiTimeoutError(error) || isApiDeadlineError(error)) throw error;
+        }
+        if (proxyError || (!response.ok && shouldFallbackFromHostProxy(responseText, response.status))) {
+          transport = proxyError ? 'direct-after-proxy-error' : `direct-after-proxy-${response.status}`;
+          url = upstreamUrl;
+          ({ response, responseText } = await fetchText(upstreamUrl, {
             method: 'POST',
             headers: getAuthHeaders(settings),
             body: requestText,
@@ -821,7 +1105,7 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
           }));
         }
       } else {
-        ({ response, responseText } = await fetchText(url, {
+        ({ response, responseText } = await fetchText(upstreamUrl, {
           method: 'POST',
           headers: getAuthHeaders(settings),
           body: requestText,
@@ -830,13 +1114,14 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
           deadlineMs: runContext.deadlineMs || 0,
         }));
       }
-      // 调试快照同样默认关闭，避免无条件把完整请求/响应暂存在 globalThis
+      traceRequestToUi('POST', upstreamUrl, response.status, transport);
       if (globalThis.__bs_biotracker_debug_api__) {
         globalThis[DEBUG_LAST_API_RESPONSE_KEY] = {
           capturedAt: Date.now(),
           attempt,
           transport,
-          url: transport === 'host-proxy' ? '/api/backends/chat-completions/generate' : url,
+          format: fmt,
+          url,
           status: response.status,
           ok: response.ok,
           responseText,
@@ -845,23 +1130,24 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
       }
       logApiDebug(`response:${attempt}`, {
         transport,
-        url: transport === 'host-proxy' ? '/api/backends/chat-completions/generate' : url,
+        url,
         status: response.status,
         ok: response.ok,
         responseText,
         requestText,
       });
-      return { response, responseText, requestText };
+      return { response, responseText, requestText, format: fmt };
     } catch (error) {
+      traceRequestToUi('POST', upstreamUrl, 0, transport);
       logApiDebug(`error:${attempt}`, {
         transport,
         url,
-        requestBody,
+        requestBody: payloadForTransport,
         requestText,
         error,
       });
       if (isApiTimeoutError(error) || isApiDeadlineError(error)) throw error;
-      throw new Error(`无法连接到 API。请检查 Base URL、API Key、服务是否启动；浏览器环境会优先通过酒馆后端代理。原始错误: ${String(error?.message || error)}`);
+      throw new Error(`无法连接到 API。请检查 Base URL、API Key、服务是否启动；浏览器环境会优先通过酒馆后端代理。若使用原版 SillyTavern 且渠道不允许浏览器直连（CORS 拦截），可在 config.yaml 设置 corsProxy.enabled: true 后重启，让酒馆服务器代为转发。原始错误: ${String(error?.message || error)}`);
     } finally {
       globalThis.__bs_biotracker_async_request__ = previousAsyncFlag;
     }
@@ -871,8 +1157,12 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
   let response = result.response;
   let responseText = result.responseText;
   let errorText = response.ok ? '' : responseText;
+  const isResponses = result.format === API_FORMATS.OPENAI_RESPONSES;
+  const isClaude = result.format === API_FORMATS.CLAUDE_MESSAGES;
+  const isGemini = result.format === API_FORMATS.GEMINI_INTERACTIONS;
+  const isNonCompatFormat = isResponses || isClaude || isGemini;
 
-  if (!response.ok && response.status === 400 && body.response_format) {
+  if (!response.ok && response.status === 400 && body.response_format && !isNonCompatFormat) {
     const fallbackBody = {
       model: body.model,
       temperature: body.temperature,
@@ -890,7 +1180,7 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
   }
 
   const invalidArgument = response.status === 400 && /invalid argument|badRequest/i.test(errorText);
-  if (!response.ok && invalidArgument) {
+  if (!response.ok && invalidArgument && !isNonCompatFormat) {
     const minimalBody = {
       model: body.model,
       messages: body.messages,
@@ -902,10 +1192,14 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
   }
 
   if (!response.ok) {
-    throw new Error(`API ${response.status}: ${sanitizeErrorText(errorText)}`);
+    throw new Error(`API ${response.status}［实际请求: ${getApiUrlForFormat(apiBase, result.format)}］: ${sanitizeErrorText(errorText)}`);
   }
   try {
-    return JSON.parse(responseText);
+    const parsed = JSON.parse(responseText);
+    if (isResponses) return normalizeResponsesData(parsed);
+    if (isClaude) return normalizeClaudeData(parsed);
+    if (isGemini) return normalizeGeminiInteractionsData(parsed);
+    return parsed;
   } catch (error) {
     logApiDebug('parse_error', {
       status: response.status,
@@ -952,7 +1246,9 @@ export async function fetchModelList(settings) {
     } else {
       ({ response, responseText } = await fetchText(url, { method: 'GET', headers: getAuthHeaders(settings), timeoutMs: resolveModelListTimeoutMs(settings) }));
     }
+    traceRequestToUi('GET', url, response?.status, transport);
   } catch (error) {
+    traceRequestToUi('GET', url, 0, transport);
     throw new Error(`模型列表连接失败（${transport}）。请检查 Base URL / API Key；也可手动填写模型名称后直接使用追踪/注册。原始错误: ${String(error?.message || error)}`);
   }
   if (!response.ok) {

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -111,6 +111,41 @@ export const DEFAULT_SYSTEM_PROMPT = [
   '不要编造怀孕天数、胎数、流产、分娩或其他高影响事件。',
 ].join('\n');
 
+export const API_FORMATS = Object.freeze({
+  OPENAI_COMPAT: 'openai_compat',
+  CLAUDE_MESSAGES: 'claude_messages',
+  OPENAI_RESPONSES: 'openai_responses',
+  GEMINI_INTERACTIONS: 'gemini_interactions',
+});
+
+export function normalizeApiFormat(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  if (raw === API_FORMATS.OPENAI_RESPONSES || raw === 'responses' || raw === 'openai_responses' || raw === 'custom_openai_responses') return API_FORMATS.OPENAI_RESPONSES;
+  if (raw === API_FORMATS.CLAUDE_MESSAGES || raw === 'claude' || raw === 'messages' || raw === 'claude_messages' || raw === 'custom_claude_messages' || raw === 'anthropic') return API_FORMATS.CLAUDE_MESSAGES;
+  if (raw === API_FORMATS.GEMINI_INTERACTIONS || raw === 'gemini' || raw === 'interactions' || raw === 'gemini_interactions') return API_FORMATS.GEMINI_INTERACTIONS;
+  return API_FORMATS.OPENAI_COMPAT;
+}
+
+export function getApiEndpointSuffix(format) {
+  switch (normalizeApiFormat(format)) {
+    case API_FORMATS.OPENAI_RESPONSES: return '/responses';
+    case API_FORMATS.CLAUDE_MESSAGES: return '/messages';
+    case API_FORMATS.GEMINI_INTERACTIONS: return '/interactions';
+    case API_FORMATS.OPENAI_COMPAT:
+    default: return '/chat/completions';
+  }
+}
+
+export function getApiUrlForFormat(apiBase, format) {
+  const base = String(apiBase || '').trim().replace(/\/+$/, '');
+  const fmt = normalizeApiFormat(format);
+  // Google AI 原生端点必须带 API 版本；base 已以 /v1 或 /v1beta 结尾时直接拼接（与 TauriTavern build_gemini_url 一致）
+  if (fmt === API_FORMATS.GEMINI_INTERACTIONS && !/\/(v1|v1beta)$/i.test(base)) {
+    return `${base}/v1beta/interactions`;
+  }
+  return `${base}${getApiEndpointSuffix(fmt)}`;
+}
+
 export const DEFAULT_SETTINGS = Object.freeze({
   theme: 'retro',
   deviceSize: 'phone',
@@ -121,6 +156,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   trackerPromptToggles: {},
   trackerPromptToggleOverrides: {},
   apiUrl: '',
+  apiFormat: API_FORMATS.OPENAI_COMPAT,
   apiKey: '',
   model: 'gpt-4.1-mini',
   modelOptions: [],
@@ -1157,6 +1193,11 @@ export function getSettings(ctx) {
     };
     if (JSON.stringify(mergedGuides) !== JSON.stringify(settings.registryDescriptionGuides)) shouldSave = true;
     settings.registryDescriptionGuides = mergedGuides;
+  }
+  const normalizedApiFormat = normalizeApiFormat(settings.apiFormat);
+  if (settings.apiFormat !== normalizedApiFormat) {
+    settings.apiFormat = normalizedApiFormat;
+    shouldSave = true;
   }
   if (shouldSave) saveHostSettings(ctx);
   return settings;

--- a/settings.html
+++ b/settings.html
@@ -145,6 +145,17 @@
             <div class="settings_section">
               <label for="bs-bt-api-url">OpenAI 兼容 API Base URL</label>
               <input id="bs-bt-api-url" class="text_pole" type="text" placeholder="https://api.example.com/v1" />
+              <small id="bs-bt-api-endpoint-preview" class="bs-bt-inline-status" style="display:block;margin-top:4px;opacity:0.85;">端点预览：<code id="bs-bt-api-endpoint-preview-code">—</code></small>
+            </div>
+
+            <div class="settings_section">
+              <label for="bs-bt-api-format">API 格式</label>
+              <select id="bs-bt-api-format" class="text_pole">
+                <option value="openai_compat">通用（兼容 OpenAI） /chat/completions</option>
+                <option value="openai_responses">自定义（兼容 OpenAI Responses） /responses</option>
+                <option value="claude_messages">自定义（兼容 Claude Messages） /messages</option>
+                <option value="gemini_interactions">自定义（兼容 Gemini Interactions） /interactions</option>
+              </select>
             </div>
 
             <div class="settings_section">

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -256,3 +256,242 @@ test('the overall deadline terminates a run that keeps failing, without hanging 
   );
   assert.ok(calls > 0 && calls < 20, `请求次数应有界，实际 ${calls}`);
 });
+
+const RESPONSES_RESULT = {
+  output: [{
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: JSON.stringify({ operations: [] }) }],
+  }],
+};
+
+test('openai_responses format on vanilla SillyTavern goes through the /proxy/ transparent proxy', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse(RESPONSES_RESULT);
+  });
+
+  const result = await callOpenAICompatible({
+    apiUrl: 'https://opencode.example.test/zen/go/v1',
+    apiKey: 'go-key',
+    model: 'muse-spark-1.2-contributor',
+    apiFormat: 'openai_responses',
+  }, { recent_messages: [] }, 'Return JSON.');
+
+  assert.deepEqual(result, { operations: [] });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, '/proxy/https://opencode.example.test/zen/go/v1/responses');
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(body.model, 'muse-spark-1.2-contributor');
+  assert.equal(body.store, false);
+  assert.equal(Array.isArray(body.input), true);
+  assert.equal(body.input[0].role, 'developer');
+  assert.deepEqual(body.text, { format: { type: 'json_object' } });
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer go-key');
+  assert.equal(calls[0].options.headers['X-CSRF-Token'], 'test-csrf');
+});
+
+test('openai_responses format falls back to direct when the transparent proxy is disabled (404)', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    if (url.startsWith('/proxy/')) {
+      return {
+        ok: false,
+        status: 404,
+        async text() {
+          return 'CORS proxy is disabled. Enable it in config.yaml or use the --corsProxy flag.';
+        },
+      };
+    }
+    return jsonResponse(RESPONSES_RESULT);
+  });
+
+  const result = await callOpenAICompatible({
+    apiUrl: 'https://opencode.example.test/zen/go/v1',
+    apiKey: 'go-key',
+    model: 'muse-spark-1.2-contributor',
+    apiFormat: 'openai_responses',
+  }, { recent_messages: [] }, 'Return JSON.');
+
+  assert.deepEqual(result, { operations: [] });
+  assert.deepEqual(calls.map((call) => call.url), [
+    '/proxy/https://opencode.example.test/zen/go/v1/responses',
+    'https://opencode.example.test/zen/go/v1/responses',
+  ]);
+});
+
+test('openai_responses format on TauriTavern uses the format-aware host proxy', async () => {
+  const calls = [];
+  globalThis.__TAURITAVERN__ = {};
+  try {
+    installBrowserHost(async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+    });
+
+    const result = await callOpenAICompatible({
+      apiUrl: 'https://opencode.example.test/zen/go/v1',
+      apiKey: 'go-key',
+      model: 'muse-spark-1.2-contributor',
+      apiFormat: 'openai_responses',
+    }, { recent_messages: [] }, 'Return JSON.');
+
+    assert.deepEqual(result, { operations: [] });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, '/api/backends/chat-completions/generate');
+    const body = JSON.parse(calls[0].options.body);
+    assert.equal(body.custom_api_format, 'openai_responses');
+    assert.equal(body.model, 'muse-spark-1.2-contributor');
+    assert.equal(Array.isArray(body.messages), true);
+  } finally {
+    delete globalThis.__TAURITAVERN__;
+  }
+});
+
+test('claude_messages format converts to Anthropic shape through the transparent proxy', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({ content: [{ type: 'text', text: JSON.stringify({ operations: [] }) }] });
+  });
+
+  const result = await callOpenAICompatible({
+    apiUrl: 'https://opencode.example.test/zen/go/v1',
+    apiKey: 'go-key',
+    model: 'qwen3.8-max',
+    apiFormat: 'claude_messages',
+  }, { recent_messages: [] }, 'Return JSON.');
+
+  assert.deepEqual(result, { operations: [] });
+  assert.equal(calls[0].url, '/proxy/https://opencode.example.test/zen/go/v1/messages');
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(typeof body.system, 'string');
+  assert.ok(body.max_tokens >= 1);
+  assert.equal(body.messages.every((m) => m.role === 'user' || m.role === 'assistant'), true);
+  assert.equal(calls[0].options.headers['x-api-key'], 'go-key');
+  assert.equal(calls[0].options.headers['anthropic-version'], '2023-06-01');
+});
+
+const GEMINI_RESULT = {
+  status: 'completed',
+  steps: [{
+    type: 'model_output',
+    content: [{ type: 'text', text: JSON.stringify({ operations: [] }) }],
+  }],
+};
+
+test('gemini_interactions format builds steps + system_instruction and injects /v1beta', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse(GEMINI_RESULT);
+  });
+
+  const result = await callOpenAICompatible({
+    // 裸主机名（无 /v1 或 /v1beta）：插件必须自动补 /v1beta，与 TauriTavern build_gemini_url 一致
+    apiUrl: 'https://generativelanguage.googleapis.com',
+    apiKey: 'goog-key',
+    model: 'gemini-2.5-pro',
+    apiFormat: 'gemini_interactions',
+  }, { recent_messages: [] }, 'Return JSON.');
+
+  assert.deepEqual(result, { operations: [] });
+  assert.equal(calls[0].url, '/proxy/https://generativelanguage.googleapis.com/v1beta/interactions');
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(body.model, 'gemini-2.5-pro');
+  assert.equal(body.stream, false);
+  assert.equal(body.store, false);
+  assert.equal(typeof body.system_instruction, 'string');
+  assert.ok(body.system_instruction.length > 0);
+  assert.equal(Array.isArray(body.input), true);
+  assert.equal(body.input.every((s) => s.type === 'user_input' || s.type === 'model_output'), true);
+  assert.equal(body.input.some((s) => s.type === 'user_input'), true);
+  assert.ok(body.input.every((s) => Array.isArray(s.content) && s.content.every((b) => b.type === 'text')));
+  assert.equal(calls[0].options.headers['x-goog-api-key'], 'goog-key');
+  assert.equal(calls[0].options.headers.Authorization, undefined);
+});
+
+test('gemini_interactions keeps an explicit /v1beta base without double-prefixing', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse(GEMINI_RESULT);
+  });
+
+  await callOpenAICompatible({
+    apiUrl: 'https://generativelanguage.googleapis.com/v1beta',
+    apiKey: 'goog-key',
+    model: 'gemini-2.5-pro',
+    apiFormat: 'gemini_interactions',
+  }, { recent_messages: [] }, 'Return JSON.');
+
+  assert.equal(calls[0].url, '/proxy/https://generativelanguage.googleapis.com/v1beta/interactions');
+});
+
+test('gemini_interactions on TauriTavern accepts already-normalized OpenAI choices', async () => {
+  const calls = [];
+  globalThis.__TAURITAVERN__ = {};
+  try {
+    installBrowserHost(async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+    });
+
+    const result = await callOpenAICompatible({
+      apiUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      apiKey: 'goog-key',
+      model: 'gemini-2.5-pro',
+      apiFormat: 'gemini_interactions',
+    }, { recent_messages: [] }, 'Return JSON.');
+
+    assert.deepEqual(result, { operations: [] });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, '/api/backends/chat-completions/generate');
+    const body = JSON.parse(calls[0].options.body);
+    assert.equal(body.custom_api_format, 'gemini_interactions');
+    assert.equal(Array.isArray(body.messages), true);
+    assert.equal(body.custom_include_headers, 'x-goog-api-key: goog-key');
+    assert.doesNotMatch(body.custom_include_headers, /Authorization/);
+  } finally {
+    delete globalThis.__TAURITAVERN__;
+  }
+});
+
+test('gemini_interactions rejects a completed response with no model_output text', async () => {
+  installBrowserHost(async () => jsonResponse({
+    status: 'completed',
+    steps: [{ type: 'thought', signature: '' }],
+  }));
+
+  await assert.rejects(
+    callOpenAICompatible({
+      apiUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      apiKey: 'goog-key',
+      model: 'gemini-2.5-pro',
+      apiFormat: 'gemini_interactions',
+      apiTimeoutMs: 1000,
+    }, { recent_messages: [] }, 'Return JSON.'),
+    (error) => /没有可消费的文本|总时限/.test(error.message),
+  );
+});
+
+test('gemini_interactions surfaces a failed status as a retriable error', async () => {
+  installBrowserHost(async () => jsonResponse({
+    status: 'failed',
+    error: { message: 'model overloaded' },
+  }));
+
+  await assert.rejects(
+    callOpenAICompatible({
+      apiUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      apiKey: 'goog-key',
+      model: 'gemini-2.5-pro',
+      apiFormat: 'gemini_interactions',
+      apiTimeoutMs: 1000,
+    }, { recent_messages: [] }, 'Return JSON.'),
+    // failed 是可重试的上游错误：可能直接抛出，也可能在重试链里撞上总时限
+    (error) => /Gemini Interactions 回传失败|总时限/.test(error.message),
+  );
+});


### PR DESCRIPTION
## 背景 / 問題

插件原本把請求端點寫死為 OpenAI Chat Completions（`${apiBase}/chat/completions`），只相容 OpenAI 風格的渠道。但如 [OpenCode Go](https://opencode.ai/docs/zh-cn/go) 的「API 端點」表所示，不同模型走不同協定：

- **Muse Spark 1.2 Contributor / GPT 5.6 Luna / Grok 4.6** 只在 `/v1/responses` 提供（OpenAI Responses API）
- **Qwen3.7+/3.8、MiniMax** 只在 `/v1/messages` 提供（Anthropic Messages 風格）
- GLM / Kimi / MiMo / DeepSeek / LongCat 等才走 `/v1/chat/completions`

因此選用這些模型時，追蹤／註冊會直接 404／400，無法使用。

## 方案

參照 TauriTavern 的 `custom_api_formats` 四檔（`src/scripts/openai.js` 的 `openai_compat` / `openai_responses` / `claude_messages` / `gemini_interactions`），為插件增加「API 格式」下拉選單。四檔皆為完整實作（請求轉換 + 認證 + 回覆解析），非僅切換端點。

### 傳輸策略（TT 與原版 ST 皆可用）

| 格式 | 端點 | TauriTavern 宿主 | 原版 SillyTavern 宿主 |
|---|---|---|---|
| `openai_compat`（預設） | `/chat/completions` | 後端代理 → 直連回退（原有行為不變） | 同左（不變） |
| `openai_responses` | `/responses` | 後端代理帶 `custom_api_format`，由 TT 在伺服器端翻譯（沿用其 `openai_responses.rs`）→ 直連回退 | 走 ST 自帶的 `/proxy/<url>` 透傳代理（`config.yaml` 的 `corsProxy.enabled: true`，未開啟回 404 時自動回退直連） |
| `claude_messages` | `/messages` | 同上（附 `anthropic-version` / `x-api-key` 標頭） | 同左（透傳代理原樣轉發標頭） |
| `gemini_interactions` | `/interactions` | 同上 | 同左 |

### 各格式請求／回覆轉換（對齊 TauriTavern 的 payload builder）

- **Responses**：`messages → input`、`store:false`、`text.format = json_object`、`max_output_tokens`；回覆讀 `output[].content[].output_text`（或 `output_text`）。
- **Claude**：抽出 `system`、`messages → user/assistant`、`max_tokens`；回覆讀 `content[].text`。
- **Gemini Interactions**：`messages → steps`（`user_input` / `model_output` + `text` block）、`system → system_instruction`、取樣參數進 `generation_config`、`store:false`；認證改用 `x-goog-api-key`；base URL 若未以 `/v1` 或 `/v1beta` 結尾自動補 `/v1beta`（同 `build_gemini_url`）；回覆依 `status` 判定（`completed`/`requires_action` 取 `steps[].model_output.content[].text`，`failed` 拋錯並進入重試鏈）。
- 三者回覆統一正規化為 `{choices:[{message:{content}}]}`，既有 JSON 解析／重試管線無需改動。

錯誤訊息與連線狀態列會顯示「方法 + 實際 URL + HTTP 狀態 + 傳輸層」，無主控台的桌面環境也能核對請求去了哪裡。

### 具體改動

- `scripts/state.js`：新增 `API_FORMATS` / `normalizeApiFormat` / `getApiEndpointSuffix` / `getApiUrlForFormat`；`DEFAULT_SETTINGS` 增加 `apiFormat`，舊存檔自動遷移（不影響既有設定）
- `scripts/api.js`：
  - `getApiBase` 同時剝離 `/responses` `/messages` `/interactions` 尾綴
  - `getAuthHeaders` 依格式決定標頭（Claude 加 `anthropic-version`/`x-api-key`；Gemini 用 `x-goog-api-key`）
  - `requestChatCompletion` 依格式路由端點與請求體；非 compat 格式不套用 `response_format`／minimal 回退（避免用 OpenAI 欄位污染原生 payload）
  - 非 compat 格式：TT → 格式感知代理；ST/Luker → `/proxy/` 透傳代理；皆不可用 → 直連回退，失敗時提示可開啟 `corsProxy.enabled`
- `settings.html`：「API 格式」四檔下拉 + 端點即時預覽
- `index.js`：表單讀寫綁定 `apiFormat`，document 級事件委派（不依賴面板掛載時機），切換格式即自動保存
- `tests/api.test.mjs`：新增 7 個傳輸鏈路／轉換測試（ST 透傳、透傳 404 回退直連、TT 格式感知代理、Claude 請求體轉換、Responses 請求／回覆、Gemini steps 轉換 + `/v1beta` 注入 + `x-goog-api-key`、Gemini `failed` 狀態處理）

## 相容性

- 預設 `openai_compat`，GLM／Kimi／MiMo／DeepSeek 等現有使用者零影響（原有代理／回退鏈路與測試全數保留）
- TT 路徑依賴 TT 後端既有的 `custom_api_format` 支援；ST 路徑依賴 ST 既有的 `/proxy/` 透傳代理，皆不需宿主端改動

## 測試

- `node --test tests/*.test.mjs`：220/220 通過（含新增 7 案）
- TT + OpenCode Go 實測：`muse-spark-1.2-contributor` 走 `/responses` 追蹤正常
