### PR TITLE
feat: 原版 ST 後端代理請求補自訂 User-Agent（防風控誤攔），TT 保持產品 UA 不動

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -164,30 +164,44 @@ function getHostProxyHeaders(extraHeaders = {}) {
   return headers;
 }
 
+/**
+ * 上游识别用 User-Agent（仅注入后端代理路径，见 buildHostProxyConfig）：
+ * 不带版本避免与 manifest.json 漂移，仓库 URL 供提供商核对来源。
+ */
+const PLUGIN_USER_AGENT = 'BS-BioTracker (+https://github.com/Liuuuu54/st_bs_biotracker)';
+
 function buildHostProxyConfig(apiBase, settings) {
   const apiKey = String(settings?.apiKey || '');
   const format = normalizeApiFormat(settings?.apiFormat);
-  let customIncludeHeaders = '';
+  const headerLines = [];
   if (apiKey) {
     if (format === API_FORMATS.GEMINI_INTERACTIONS) {
       // Google AI 认 x-goog-api-key；Authorization: Bearer 会被当成 OAuth 而 401
-      customIncludeHeaders = `x-goog-api-key: ${apiKey}`;
+      headerLines.push(`x-goog-api-key: ${apiKey}`);
     } else if (format === API_FORMATS.CLAUDE_MESSAGES) {
-      customIncludeHeaders = [
+      headerLines.push(
         `Authorization: Bearer ${apiKey}`,
         `x-api-key: ${apiKey}`,
         'anthropic-version: 2023-06-01',
-      ].join('\n');
+      );
     } else {
-      customIncludeHeaders = `Authorization: Bearer ${apiKey}`;
+      headerLines.push(`Authorization: Bearer ${apiKey}`);
     }
+  }
+  // 原版 ST 后端用 node-fetch 发上游请求，默认 UA 是通用的 "node-fetch"；
+  // 部分提供商（如 OpenCode Go）拿 UA 做反欺诈信号，泛用 bot UA 可能被拦。
+  // custom_include_headers 会在 ST 后端合并进上游请求头（mergeObjectWithYaml），
+  // 足以覆盖默认值。TauriTavern 后端自带产品 UA（TauriTavern/<ver>）且
+  // additional headers 最后应用，注入这里会把产品 UA 顶掉，故 TT 跳过。
+  if (!hostSupportsFormatAwareProxy()) {
+    headerLines.push(`User-Agent: ${PLUGIN_USER_AGENT}`);
   }
   return {
     chat_completion_source: 'custom',
     custom_url: apiBase,
     reverse_proxy: apiBase,
     proxy_password: apiKey,
-    custom_include_headers: customIncludeHeaders,
+    custom_include_headers: headerLines.join('\n'),
   };
 }
 

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -68,6 +68,11 @@ test('fetchModelList uses the SillyTavern backend proxy for a cross-origin API',
   assert.equal(body.custom_url, 'https://example-model-host.test/v1');
   assert.equal(body.reverse_proxy, 'https://example-model-host.test/v1');
   assert.equal(body.proxy_password, '');
+  // 无密钥时 ST 后端代理仍应带自定义 UA（node-fetch 默认 UA 的覆盖与密钥无关）
+  assert.equal(
+    body.custom_include_headers,
+    'User-Agent: BS-BioTracker (+https://github.com/Liuuuu54/st_bs_biotracker)',
+  );
 });
 
 test('callOpenAICompatible sends chat completions through the SillyTavern backend proxy', async () => {
@@ -92,7 +97,14 @@ test('callOpenAICompatible sends chat completions through the SillyTavern backen
   assert.equal(body.chat_completion_source, 'custom');
   assert.equal(body.custom_url, 'https://example-model-host.test/v1');
   assert.equal(body.proxy_password, 'secret-key');
-  assert.equal(body.custom_include_headers, 'Authorization: Bearer secret-key');
+  // ST 后端代理必须带自定义 UA（覆盖 node-fetch 默认），且不能破坏 Authorization 行
+  assert.deepEqual(
+    body.custom_include_headers.split('\n').sort(),
+    [
+      'Authorization: Bearer secret-key',
+      'User-Agent: BS-BioTracker (+https://github.com/Liuuuu54/st_bs_biotracker)',
+    ].sort(),
+  );
   assert.equal(body.model, 'grok-compatible');
   assert.equal(body.stream, false);
   assert.deepEqual(body.response_format, { type: 'json_object' });


### PR DESCRIPTION
## 背景

OpenCode Go 官方近期提醒（原帖大意）：由于 API key 共享/濫用的欺詐變多，他們把 **User-Agent 當作識別信號**，自建 agent 務必自帶 custom UA。

對應到本插件，我把四條請求路徑的實際上游 UA 全部核了一遍：

| 請求路徑 | 上游實際 UA | 結論 |
|---|---|---|
| TauriTavern 後端代理 | `TauriTavern/<版本>`（TT 產品 UA，`tt-adapter-http` 的 `builder.user_agent(...)`） | ✅ 本來就合規 |
| 瀏覽器直連（含 ST `/proxy/` 透傳） | 瀏覽器真實 UA（`User-Agent` 是瀏覽器 forbidden header，插件改不了，但必然存在；ST `corsProxy` 亦原樣轉發） | ✅ 正常瀏覽器信號 |
| **原版 ST 後端代理**（`/api/backends/chat-completions/generate` 與 `/status`） | **`node-fetch`**（ST 用 node-fetch v3，未顯式設定時補通用默認值） | ⚠️ 唯一的弱點：泛用 bot UA，可能被風控 |

## 改動

僅一處：`buildHostProxyConfig` 的 `custom_include_headers` 追加一行

```
User-Agent: BS-BioTracker (+https://github.com/Liuuuu54/st_bs_biotracker)
```

生效機制（均已實證）：

- ST 後端在 generate（`chat-completions.js` custom 源分支）與 status 兩條路徑上都會 `mergeObjectWithYaml(headers, custom_include_headers)` 合併進上游請求頭；node-fetch v3 只在**沒有人工 UA 時**才補默認值（`if (!headers.has('User-Agent'))`），因此本行會穩定覆蓋 `node-fetch`。
- 用 ST 同款的 `yaml` 包實測驗證：無密鑰單行、compat 兩行、claude 四行三種拼接結果都能被 `yaml.parse` 正確解析成對應 header map（UA 值不含 `: ` 與 ` #`，plain scalar 安全）。
- **TauriTavern 跳過注入**：TT 的 `apply_additional_headers` 在最後一步應用（用戶頭覆蓋內建頭），注入會把 TT 自帶的 `TauriTavern/<版本>` 產品 UA 頂掉——那個 UA 本來就是合規的自定義信號，沒有理由覆蓋，故以宿主判斷跳過，TT 使用者零變化。
- UA 刻意不含版本號，避免與 `manifest.json` 的版本各自漂移；帶倉庫 URL 方便提供商核對來源。

## 相容性

- 直連／透傳路徑完全未動（瀏覽器也不允許改 UA，真實瀏覽器 UA 本就是正常信號）。
- 對現有 ST 使用者：僅上游看到的 `node-fetch` 變成插件標識；若某個渠道依賴攔截非瀏覽器 UA（極少見），可再反饋。
- Luker 宿主按 ST 同路處理（其後端為 ST 系，不識別時僅是多一列無害標頭）。

## 測試

- `tests/api.test.mjs`：更新 1 條、新增 2 條斷言——ST 後端代理必帶 UA 行且不破壞 Authorization 行；無密鑰 status 請求同樣帶 UA；TT 格式感知代理保持不注入（既有 `x-goog-api-key` 全等斷言繼續守住）。
- `node --test tests/*.test.mjs`：**222/222 通過**。
