### PR TITLE
fix: 同一樓層吐字中與收尾各追一次，改為主生成＋MVU 結束後只追一次（替換靜默吸收）

### DIFF
--- a/index.js
+++ b/index.js
@@ -5719,7 +5719,6 @@ function applySettingsToForm(ctx) {
   setValue('bs-bt-model', settings.model);
   updateApiEndpointPreview();
   setValue('bs-bt-formatted-output-v4', settings.formattedOutputV4 !== false);
-  setValue('bs-bt-mvu-extra-analysis-compat', settings.mvuExtraAnalysisCompat !== false);
   setValue('bs-bt-race-catalog', settings.raceCatalogInPrompt !== false);
   setValue('bs-bt-trigger', settings.triggerTiming);
   setValue('bs-bt-poll-ms', settings.pollMs);
@@ -6286,8 +6285,6 @@ function readSettingsFromForm(ctx) {
   settings.model = String(getValue('bs-bt-model')).trim();
   const formattedOutputToggle = document.getElementById('bs-bt-formatted-output-v4');
   if (formattedOutputToggle) settings.formattedOutputV4 = Boolean(formattedOutputToggle.checked);
-  const mvuCompatToggle = document.getElementById('bs-bt-mvu-extra-analysis-compat');
-  if (mvuCompatToggle) settings.mvuExtraAnalysisCompat = Boolean(mvuCompatToggle.checked);
   const raceCatalogToggle = document.getElementById('bs-bt-race-catalog');
   if (raceCatalogToggle) settings.raceCatalogInPrompt = Boolean(raceCatalogToggle.checked);
   settings.triggerTiming = String(getValue('bs-bt-trigger')).trim() || 'after_ai';

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1859,6 +1859,10 @@ function trimChatStateSnapshots(chatState) {
       boundarySignature: String(chatState.snapshots[0].boundarySignature || ''),
       reason: String(chatState.snapshots[0].reason || 'state'),
       createdAt: Number(chatState.snapshots[0].createdAt || Date.now()),
+      anchorVersion: Number(chatState.snapshots[0].anchorVersion) || 0,
+      tailMessageId: String(chatState.snapshots[0].tailMessageId || ''),
+      tailSwipeId: String(chatState.snapshots[0].tailSwipeId || ''),
+      tailName: String(chatState.snapshots[0].tailName || ''),
       snapshotMode: 'full',
       stateSnapshot: materializedFirstPayload,
     };
@@ -1906,6 +1910,12 @@ function createStoredSnapshotState(snapshots, payload, metadata = {}, cache = ne
     boundarySignature: String(metadata.boundarySignature || ''),
     reason: String(metadata.reason || 'state'),
     createdAt: Number(metadata.createdAt || Date.now()),
+    // 靜默正文替換識別錨點（anchorVersion 1）：記錄邊界樓層的身分。舊快照沒有
+    // 這些欄位（anchorVersion 0）→ 永遠走原本的判定，零回歸。
+    anchorVersion: Number(metadata.anchorVersion) || 0,
+    tailMessageId: metadata.tailMessageId === undefined || metadata.tailMessageId === null ? '' : String(metadata.tailMessageId),
+    tailSwipeId: metadata.tailSwipeId === undefined || metadata.tailSwipeId === null ? '' : String(metadata.tailSwipeId),
+    tailName: metadata.tailName === undefined || metadata.tailName === null ? '' : String(metadata.tailName),
   };
 
   if (shouldStoreFullSnapshot(snapshotIndex, normalizedPayload, deltaPatch)) {
@@ -1977,6 +1987,10 @@ function repackChatStateSnapshots(chatState) {
       boundarySignature: snapshot?.boundarySignature,
       reason: snapshot?.reason,
       createdAt: snapshot?.createdAt,
+      anchorVersion: snapshot?.anchorVersion,
+      tailMessageId: snapshot?.tailMessageId,
+      tailSwipeId: snapshot?.tailSwipeId,
+      tailName: snapshot?.tailName,
     }, repackedCache);
     repackedSnapshots.push(stored);
     repackedCache.set(repackedSnapshots.length - 1, cloneValue(payload));
@@ -2046,6 +2060,10 @@ export function recordChatStateSnapshot(ctx, chatState, options = {}) {
       boundarySignature: buildBoundaryMessageSignature(ctx, messageCount),
       reason: String(options.reason || 'state'),
       createdAt: Date.now(),
+      anchorVersion: options.anchorVersion,
+      tailMessageId: options.tailMessageId,
+      tailSwipeId: options.tailSwipeId,
+      tailName: options.tailName,
     },
   );
   chatState.snapshots.push(snapshot);

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -167,7 +167,6 @@ export const DEFAULT_SETTINGS = Object.freeze({
   model: 'gpt-4.1-mini',
   modelOptions: [],
   formattedOutputV4: true,
-  mvuExtraAnalysisCompat: true,
   raceCatalogInPrompt: true,
   triggerTiming: 'after_ai',
   pollMs: 1800,

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1862,6 +1862,8 @@ function trimChatStateSnapshots(chatState) {
       tailMessageId: String(chatState.snapshots[0].tailMessageId || ''),
       tailSwipeId: String(chatState.snapshots[0].tailSwipeId || ''),
       tailName: String(chatState.snapshots[0].tailName || ''),
+      hostMutSeq: Number.isFinite(Number(chatState.snapshots[0].hostMutSeq)) ? Number(chatState.snapshots[0].hostMutSeq) : -1,
+      replacementStamp: Number.isFinite(Number(chatState.snapshots[0].replacementStamp)) ? Number(chatState.snapshots[0].replacementStamp) : 0,
       snapshotMode: 'full',
       stateSnapshot: materializedFirstPayload,
     };
@@ -1909,12 +1911,15 @@ function createStoredSnapshotState(snapshots, payload, metadata = {}, cache = ne
     boundarySignature: String(metadata.boundarySignature || ''),
     reason: String(metadata.reason || 'state'),
     createdAt: Number(metadata.createdAt || Date.now()),
-    // 靜默正文替換識別錨點（anchorVersion 1）：記錄邊界樓層的身分。舊快照沒有
-    // 這些欄位（anchorVersion 0）→ 永遠走原本的判定，零回歸。
+    // 靜默正文替換識別錨點（anchorVersion 1）：記錄邊界樓層的身分、「當時的編輯
+    // 事件計數」與「當時已見的替換戳值」。舊快照沒有這些欄位（anchorVersion 0）
+    // → 永遠走原本的判定，零回歸。
     anchorVersion: Number(metadata.anchorVersion) || 0,
     tailMessageId: metadata.tailMessageId === undefined || metadata.tailMessageId === null ? '' : String(metadata.tailMessageId),
     tailSwipeId: metadata.tailSwipeId === undefined || metadata.tailSwipeId === null ? '' : String(metadata.tailSwipeId),
     tailName: metadata.tailName === undefined || metadata.tailName === null ? '' : String(metadata.tailName),
+    hostMutSeq: Number.isFinite(Number(metadata.hostMutSeq)) ? Number(metadata.hostMutSeq) : -1,
+    replacementStamp: Number.isFinite(Number(metadata.replacementStamp)) ? Number(metadata.replacementStamp) : 0,
   };
 
   if (shouldStoreFullSnapshot(snapshotIndex, normalizedPayload, deltaPatch)) {
@@ -1990,6 +1995,8 @@ function repackChatStateSnapshots(chatState) {
       tailMessageId: snapshot?.tailMessageId,
       tailSwipeId: snapshot?.tailSwipeId,
       tailName: snapshot?.tailName,
+      hostMutSeq: snapshot?.hostMutSeq,
+      replacementStamp: snapshot?.replacementStamp,
     }, repackedCache);
     repackedSnapshots.push(stored);
     repackedCache.set(repackedSnapshots.length - 1, cloneValue(payload));
@@ -2063,6 +2070,8 @@ export function recordChatStateSnapshot(ctx, chatState, options = {}) {
       tailMessageId: options.tailMessageId,
       tailSwipeId: options.tailSwipeId,
       tailName: options.tailName,
+      hostMutSeq: options.hostMutSeq,
+      replacementStamp: options.replacementStamp,
     },
   );
   chatState.snapshots.push(snapshot);

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -453,6 +453,11 @@ export function installHostRunWatchers(ctx) {
   const source = ctx?.eventSource;
   if (!source || typeof source.on !== 'function') return;
   hostRunState.ctxRef = ctx;
+  // 安装即回填持久计数：首个编辑事件即使在任何轮询评估之前到达，
+  // 也在正确的基准上自增，不会把存档里的大计数覆成小值
+  try {
+    hydrateHostMutSeq(getSettings(ctx));
+  } catch {}
   // 无论订到第几个都标记为已安装、不再重试：宿主 eventSource.on 实际不会抛，
   // 万一抛了也只可能缺一腿，重复叠加监听反而会把深度计数订乱
   hostRunState.listenersInstalled = true;

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -423,13 +423,20 @@ function markHostGenerationEnd() {
 }
 
 function bumpHostMutSeq() {
+  // 先回填再自增：重载后「首次轮询（hydrate）之前就来了编辑事件」时，
+  // 不回填会把持久化的大计数覆成小值，令锚点比对失效、编辑被吞
+  const ctx = hostRunState.ctxRef;
+  let settings = null;
+  try {
+    settings = ctx ? getSettings(ctx) : null;
+    if (settings) hydrateHostMutSeq(settings);
+  } catch {}
   hostRunState.mutSeq += 1;
   // 立即持久化：编辑事件是低频人工操作，直接存不心疼；不存的话「编辑后未及
   // 保存就重载」会让下一会话的回填值偏小、编辑痕迹丢失
   try {
-    const ctx = hostRunState.ctxRef;
-    if (ctx) {
-      getSettings(ctx).hostMutSeqCounter = hostRunState.mutSeq;
+    if (settings && ctx) {
+      settings.hostMutSeqCounter = hostRunState.mutSeq;
       saveSettings(ctx);
     }
   } catch {}
@@ -455,6 +462,12 @@ export function installHostRunWatchers(ctx) {
     source.on(resolveHostEventName(ctx, 'GENERATION_ENDED', 'generation_ended'), markHostGenerationEnd);
     source.on(resolveHostEventName(ctx, 'MESSAGE_EDITED', 'message_edited'), bumpHostMutSeq);
     source.on(resolveHostEventName(ctx, 'MESSAGE_SWIPED', 'message_swiped'), bumpHostMutSeq);
+    // 酒馆助手 ts_edit / JS-Runner 等程序化编辑只发 MESSAGE_UPDATED（不发 EDITED），
+    // /role /name 与编辑取消也走这里：漏订会让「替换后脚本改正文」被当成替换吞掉。
+    // 取消编辑会误前进计数 → 该轮替换不被吸收、多追一次，方向安全。
+    // 宿主 setChatMessages(refresh:'affected') 只发 *_MESSAGE_RENDERED，替换写回
+    // 本身不会误触发本计数。
+    source.on(resolveHostEventName(ctx, 'MESSAGE_UPDATED', 'message_updated'), bumpHostMutSeq);
   } catch (error) {
     console.warn('[BS BioTracker] 無法訂閱宿主生成/編輯事件', error);
   }

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -320,7 +320,7 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
     // 但正文替换的落库同样会改变内容指纹：它的戳记晚于等待起点时只更新指纹、
     // 不重排等待起点，否则每次替换都会把宽限续满，MVU 结束后的追踪被越推越晚。
     mvuGateState.pendingContentKey = contentKey;
-    if (!isReplacementAfter(mvuGateState.pendingSince, last)) {
+    if (!isReplacementAfter({ stampedAt: mvuGateState.pendingSince }, last)) {
       mvuGateState.pendingSince = now;
       mvuGateState.sawGenerateThisRound = false;
     }
@@ -341,7 +341,8 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
   // 结束事件与评估之间正文若被替换改写过（指纹对不上），只要替换戳晚于结束事件，
   // 说明 MVU 的产物已落定、无需再等宽限——直接放行，在最终正文上只追一轮
   const endedKeyMatch = mvuGateState.lastEndedKey === roundKey;
-  const replacementAfterEnd = endedKeyMatch && isReplacementAfter(mvuGateState.lastEndedAt, last);
+  const replacementAfterEnd = endedKeyMatch
+    && isReplacementAfter({ stampedAt: mvuGateState.lastEndedAt }, last);
   const waiting = resolveMvuGateWaiting(roundKey, contentKey, now, during || generateActive, replacementAfterEnd);
   // 等待全程静默：MVU 解析结束紧接着就是追踪提示，中间再弹一条等待提示纯属噪音；
   // 排查时看 console 即可
@@ -391,6 +392,11 @@ const hostRunState = {
   listenersInstalled: false,
   generationDepth: 0,
   generationBusySince: 0,
+  // 编辑/抽卡事件计数：吸收判定要求「回执之后没有编辑事件」。持久化到
+  // settings.hostMutSeqCounter 并在载入时回填，重载后继续单调递增——纯内存
+  // 计数重载归零会把「重载后的手动编辑」误判成无痕而吞掉追踪。
+  mutSeq: 0,
+  ctxRef: null,
 };
 export const __hostRunStateForTest = hostRunState;
 // 与 MVU 门控同法：挂到全局方便在真实宿主的 console 里排查触发问题
@@ -416,10 +422,30 @@ function markHostGenerationEnd() {
   hostRunState.generationBusySince = 0;
 }
 
+function bumpHostMutSeq() {
+  hostRunState.mutSeq += 1;
+  // 立即持久化：编辑事件是低频人工操作，直接存不心疼；不存的话「编辑后未及
+  // 保存就重载」会让下一会话的回填值偏小、编辑痕迹丢失
+  try {
+    const ctx = hostRunState.ctxRef;
+    if (ctx) {
+      getSettings(ctx).hostMutSeqCounter = hostRunState.mutSeq;
+      saveSettings(ctx);
+    }
+  } catch {}
+}
+
+/** 从持久化存档回填编辑计数（重载后 max(内存, 存档) 起步，保持单调）。 */
+export function hydrateHostMutSeq(settings) {
+  const persisted = Number(settings?.hostMutSeqCounter);
+  if (Number.isFinite(persisted) && persisted > hostRunState.mutSeq) hostRunState.mutSeq = persisted;
+}
+
 export function installHostRunWatchers(ctx) {
   if (hostRunState.listenersInstalled) return;
   const source = ctx?.eventSource;
   if (!source || typeof source.on !== 'function') return;
+  hostRunState.ctxRef = ctx;
   // 无论订到第几个都标记为已安装、不再重试：宿主 eventSource.on 实际不会抛，
   // 万一抛了也只可能缺一腿，重复叠加监听反而会把深度计数订乱
   hostRunState.listenersInstalled = true;
@@ -427,8 +453,10 @@ export function installHostRunWatchers(ctx) {
     source.on(resolveHostEventName(ctx, 'GENERATION_STARTED', 'generation_started'), markHostGenerationStart);
     source.on(resolveHostEventName(ctx, 'GENERATION_STOPPED', 'generation_stopped'), markHostGenerationEnd);
     source.on(resolveHostEventName(ctx, 'GENERATION_ENDED', 'generation_ended'), markHostGenerationEnd);
+    source.on(resolveHostEventName(ctx, 'MESSAGE_EDITED', 'message_edited'), bumpHostMutSeq);
+    source.on(resolveHostEventName(ctx, 'MESSAGE_SWIPED', 'message_swiped'), bumpHostMutSeq);
   } catch (error) {
-    console.warn('[BS BioTracker] 無法訂閱宿主生成事件', error);
+    console.warn('[BS BioTracker] 無法訂閱宿主生成/編輯事件', error);
   }
 }
 
@@ -480,6 +508,12 @@ function getFloorAnchorFields(message) {
       : String(message.id),
     tailSwipeId: message?.swipe_id === undefined || message?.swipe_id === null ? '' : String(message.swipe_id),
     tailName: String(message?.name || ''),
+    // 盖锚时刻的编辑计数与当时已见的替换戳值：吸收要求「之后没有编辑事件」
+    // 且「戳值相对锚点前进过」——只认戳晚于回执会把「替换后的手动编辑」一起吞掉
+    hostMutSeq: hostRunState.mutSeq,
+    replacementStamp: readReplacementMarkMs(message),
+    // 内存侧锚点时刻（在飞比对用）；快照持久化侧用 createdAt
+    stampedAt: Date.now(),
   };
 }
 
@@ -496,10 +530,20 @@ function sameFloorIdentity(stamp, currentFloor) {
   return true;
 }
 
-/** 正文替换时间戳晚于锚点时刻 = 之后确有替换写回（跨重载有效，不依赖内存计数）。 */
-function isReplacementAfter(anchorAtMs, currentFloor) {
+/**
+ * 楼层当前的替换戳是否「相对锚点前进过」= 锚点之后确有新的替换写回。
+ * 锚点带 replacementStamp（吸收快照记录了当时已见的戳值）时要求戳值严格大于它
+ * ——戳没前进而内容变了必然不是替换（是编辑或其他写回者），不得吸收；
+ * 旧锚点没有该字段（tracker 回执）时回退「戳晚于锚点时刻」判定。
+ */
+function isReplacementAfter(snapshot, currentFloor) {
+  const stamp = readReplacementMarkMs(currentFloor);
+  if (!stamp) return false;
+  const lastSeen = Number(snapshot?.replacementStamp);
+  if (Number.isFinite(lastSeen) && lastSeen > 0) return stamp > lastSeen;
+  const anchorAtMs = Number(snapshot?.createdAt) || Number(snapshot?.stampedAt);
   if (!anchorAtMs) return false;
-  return readReplacementMarkMs(currentFloor) > Number(anchorAtMs);
+  return stamp > anchorAtMs;
 }
 
 function findReplacementAnchorSnapshot(chatState, count) {
@@ -515,11 +559,14 @@ function findReplacementAnchorSnapshot(chatState, count) {
 }
 
 /**
- * 数据库正文替换的静默吸收：追踪回执所在楼层带着晚于回执的替换时间戳时，
- * 就地重锚快照与 lastProcessedSignature，下一轮不再发出追踪请求。
- * 返回 true = 本轮轮询已被吸收。恒生效、无开关、无提示。
+ * 数据库正文替换的静默吸收：追踪回执所在楼层带着「相对锚点前进过的替换戳」、
+ * 且锚点之后没有编辑/抽卡事件时，就地重锚快照与 lastProcessedSignature，
+ * 下一轮不再发出追踪请求。返回 true = 本轮轮询已被吸收。恒生效、无开关、无提示。
+ * 只认「戳晚于回执」会把「替换后用户又手动编辑」一起吞掉（编辑不动戳），
+ * 因此编辑事件计数与戳值前进是必要条件；两者皆有持久化，跨重载成立。
  */
 export function tryAdoptSilentTailReplacement(ctx, settings, chatState) {
+  hydrateHostMutSeq(settings);
   const chat = getHostChat(ctx);
   const count = chat.length;
   if (count <= 0) return false;
@@ -531,8 +578,11 @@ export function tryAdoptSilentTailReplacement(ctx, settings, chatState) {
   const snapshot = findReplacementAnchorSnapshot(chatState, count);
   if (!snapshot || Number(snapshot.anchorVersion) !== 1) return false;
   if (!sameFloorIdentity(snapshot, last)) return false;
-  if (!isReplacementAfter(snapshot.createdAt, last)) return false;
+  if (!isReplacementAfter(snapshot, last)) return false;
+  const stampSeq = Number(snapshot.hostMutSeq);
+  if (Number.isFinite(stampSeq) && stampSeq >= 0 && hostRunState.mutSeq > stampSeq) return false;
   if (isHostGenerationBusy(ctx)) return false;
+  settings.hostMutSeqCounter = hostRunState.mutSeq;
   recordChatStateSnapshot(ctx, chatState, {
     messageCount: count,
     reason: 'silent_replace',
@@ -540,7 +590,7 @@ export function tryAdoptSilentTailReplacement(ctx, settings, chatState) {
   });
   chatState.lastProcessedSignature = currentSignature;
   saveSettings(ctx);
-  console.debug('[BS BioTracker] 偵測到正文替換回寫（楼层带替换戳记且晚于追踪回执），已重新锚定，未重發請求');
+  console.debug('[BS BioTracker] 偵測到正文替換回寫（替换戳前进且无编辑事件），已重新锚定，未重發請求');
   return true;
 }
 
@@ -1427,10 +1477,10 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   const attemptedSignature = buildSignature(ctx, messageIndex + 1);
   chatState.lastAttemptedSignature = attemptedSignature;
   saveSettings(ctx);
-  // 记下发出请求那一刻楼层的样子与时刻：返回时正文若有变化，用它区分
-  // 「重掷/编辑/删楼的合法改动」与「正文替换的静默改写（带替换戳记）」
+  // 记下发出请求那一刻楼层的样子与编辑计数：返回时正文若有变化，用它区分
+  // 「重掷/编辑/删楼的合法改动」与「正文替换的静默改写（替换戳前进且无编辑事件）」
+  hydrateHostMutSeq(settings);
   const preCallFloorStamp = getFloorAnchorFields(chat[messageIndex]);
-  const preCallAtMs = Date.now();
   const systemPrompt = buildTrackerSystemPrompt(settings.systemPrompt || DEFAULT_SYSTEM_PROMPT, settings.registryDescriptionGuides || null, payload);
   recordTrackerRequestDebug(systemPrompt, payload);
   const rawResult = await callOpenAICompatible(
@@ -1452,13 +1502,15 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
     console.warn('[BS BioTracker] 分析后刷新聊天视图失败，改用现有视图比对', error);
   }
   const postCallSignature = buildSignature(ctx, messageIndex + 1);
-  // 在飞期间正文被改写的三种可能按「楼层带晚于发出时刻的替换戳记」一笔判定：
-  // 命中即正文替换（分析对象仍是替换前正文，结果对剧情有效）——沿用结果、
-  // 就地重锚，不作废重跑；重掷/编辑/删楼不会盖出戳记，照旧作废整份结果。
+  // 在飞期间正文被改写：只有「替换戳相对发出时前进、且没有编辑/抽卡事件、
+  // 同楼层同身份」才算正文替换（分析对象仍是替换前正文，结果对剧情有效）——
+  // 沿用结果、就地重锚；替换后又手改（编辑事件）、或重掷/删楼照旧作废整份结果。
+  const currentFloorAfterCall = getHostChat(ctx)[messageIndex];
   const silentReplacementDuringRun = postCallSignature !== attemptedSignature
     && getHostChat(ctx).length === messageIndex + 1
-    && sameFloorIdentity(preCallFloorStamp, getHostChat(ctx)[messageIndex])
-    && isReplacementAfter(preCallAtMs, getHostChat(ctx)[messageIndex])
+    && sameFloorIdentity(preCallFloorStamp, currentFloorAfterCall)
+    && isReplacementAfter(preCallFloorStamp, currentFloorAfterCall)
+    && hostRunState.mutSeq === preCallFloorStamp.hostMutSeq
     && !isHostGenerationBusy(ctx);
   if (postCallSignature !== attemptedSignature && !silentReplacementDuringRun) {
     console.warn('[BS BioTracker] 该消息在分析期间被修改或删除，本次结果已作废');
@@ -1481,6 +1533,7 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   chatState.lastProcessedSignature = silentReplacementDuringRun ? postCallSignature : attemptedSignature;
   chatState.lastFailedSignature = '';
   chatState.lastFailedChatSignature = '';
+  settings.hostMutSeqCounter = hostRunState.mutSeq;
   recordChatStateSnapshot(ctx, chatState, {
     messageCount: messageIndex + 1,
     reason: 'tracker',

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -71,8 +71,6 @@ const mvuGateState = {
   pendingKey: '',
   pendingContentKey: '',
   pendingSince: 0,
-  // 提示只在每个聊天第一次真正等待时弹一次：逐轮提示在长对话里等同于噪音
-  announcedChatKey: '',
   // fetch 钩子观测：正文之后出现的额外生成请求（MVU 额外模型解析的硬信号）
   fetchHooked: false,
   generateInFlight: 0,
@@ -178,7 +176,7 @@ function getMvuContentKey(ctx) {
   return buildSignature(ctx, getHostChat(ctx).length);
 }
 
-function installMvuGateListener(ctx) {
+export function installMvuGateListener(ctx) {
   if (mvuGateState.eventInstalled) return;
   const handler = () => {
     const key = getMvuRoundKey(ctx);
@@ -202,17 +200,6 @@ function installMvuGateListener(ctx) {
     console.warn('[BS BioTracker] 无法订阅 MVU 变量更新事件', error);
   }
   mvuGateState.eventInstalled = installed;
-}
-
-function notifyMvuGateWaiting(ctx) {
-  const chatKey = getChatKey(ctx);
-  if (!chatKey || mvuGateState.announcedChatKey === chatKey) return;
-  mvuGateState.announcedChatKey = chatKey;
-  try {
-    globalThis.toastr?.info?.('检测到 MVU 额外模型解析请求，等待变量更新完成后再追踪', '[BS BioTracker] MVU 兼容');
-  } catch {
-    // 无 toastr 的环境静默即可
-  }
 }
 
 function isGenerateFetchRequest(input) {
@@ -331,36 +318,232 @@ export function shouldWaitForMvuExtraAnalysis(ctx, settings) {
     mvuGateState.sawGenerateThisRound = false;
   } else if (mvuGateState.pendingContentKey !== contentKey) {
     // 同 id 消息被重掷/编辑：内容已变，视为新轮次，重新开启等待窗口，
-    // 避免旧 pendingSince 过期导致宽限路径立即放行
+    // 避免旧 pendingSince 过期导致宽限路径立即放行。
+    // 但正文替换的落库同样会改变内容指纹：它的戳记晚于等待起点时只更新指纹、
+    // 不重排等待起点，否则每次替换都会把宽限续满，MVU 结束后的追踪被越推越晚。
     mvuGateState.pendingContentKey = contentKey;
-    mvuGateState.pendingSince = now;
-    mvuGateState.sawGenerateThisRound = false;
+    if (!isReplacementAfter(mvuGateState.pendingSince, last)) {
+      mvuGateState.pendingSince = now;
+      mvuGateState.sawGenerateThisRound = false;
+    }
   }
 
   // 信号 1：MVU 全局 API 报告正在解析
   const during = mvuCapable && mvu.isDuringExtraAnalysis() === true;
-  // 信号 2：正文之后仍有非本插件的生成请求在飞行（MVU 额外解析/重试等）
-  const generateActive = mvuGateState.generateInFlight > 0;
+  // 信号 2：正文之后仍有非本插件的生成请求在飞行——仅作旧版 MVU（没有
+  // isDuringExtraAnalysis 全局）的兜底。请求特征会被误命中：数据库正文替换/
+  // 填表的请求体嵌着含 <UpdateVariable>、json_patch 字样的正文与提示词，全局
+  // 标志可得时不再采信它，否则兼容门控会串行等完数据库一整条后处理管线
+  // （TT 实测一分钟以上的延迟）。
+  const generateActive = !mvuCapable && mvuGateState.generateInFlight > 0;
   // 生成请求只作为本轮「在飞」等待信号，不参与 everSawMvuSignal——
   // 否则普通 ST 主流请求也会让设备被标记为「见过 MVU 信号」，导致每轮白等宽限
   if (during) mvuGateState.everSawMvuSignal = true;
 
-  const waiting = resolveMvuGateWaiting(roundKey, contentKey, now, during || generateActive);
-  // 提示只在真的推迟了追踪时才弹：先前无条件按「更新方式=额外模型解析」提示，
-  // 会在本轮解析早已结束、根本没等待的情况下也弹一次
-  if (waiting) notifyMvuGateWaiting(ctx);
+  // 结束事件与评估之间正文若被替换改写过（指纹对不上），只要替换戳晚于结束事件，
+  // 说明 MVU 的产物已落定、无需再等宽限——直接放行，在最终正文上只追一轮
+  const endedKeyMatch = mvuGateState.lastEndedKey === roundKey;
+  const replacementAfterEnd = endedKeyMatch && isReplacementAfter(mvuGateState.lastEndedAt, last);
+  const waiting = resolveMvuGateWaiting(roundKey, contentKey, now, during || generateActive, replacementAfterEnd);
+  // 等待全程静默：MVU 解析结束紧接着就是追踪提示，中间再弹一条等待提示纯属噪音；
+  // 排查时看 console 即可
+  if (waiting) console.debug('[BS BioTracker] MVU 額外解析尚未結束，本輪追蹤推遲');
   return waiting;
 }
 
-function resolveMvuGateWaiting(roundKey, contentKey, now, signalActive) {
+function resolveMvuGateWaiting(roundKey, contentKey, now, signalActive, replacementAfterEnd) {
   if (signalActive) return now - mvuGateState.pendingSince < MVU_EXTRA_MAX_WAIT_MS;
   // 本轮变量更新已结束（事件新鲜且内容指纹一致）→ 放行
   if (mvuGateState.lastEndedKey === roundKey
-    && mvuGateState.lastEndedContentKey === contentKey
-    && now - mvuGateState.lastEndedAt < MVU_EXTRA_ENDED_STALE_MS) return false;
+    && now - mvuGateState.lastEndedAt < MVU_EXTRA_ENDED_STALE_MS
+    && (mvuGateState.lastEndedContentKey === contentKey || replacementAfterEnd)) return false;
   // 从没见过任何 MVU 信号（非 MVU 卡）→ 不等待；见过 → 宽限期内等信号出现
   if (!mvuGateState.everSawMvuSignal) return false;
   return now - mvuGateState.pendingSince < MVU_EXTRA_WAIT_GRACE_MS;
+}
+
+// ---- 主生成忙碌闸门 / 静默正文替换吸收 ----
+// 「异步追踪 + MVU 额外模型解析 + 数据库正文替换」同时开启时，一轮回复会被追三遍：
+// 主生成没完就对着残缺正文抢发一轮（宿主串流期间按 chunk 往 mes 写半成品，
+// chunk 间隙一超过 settle 稳定窗就被判成「说完了」）、正文替换用
+// setChatMessages 原地静默改写同楼层 mes 又不发任何宿主事件，快照的边界签名
+// 失配被当成新内容又追一轮。对应两条规则：
+// 1. 轮询在「宿主主生成在飞」时不发追踪。判据只用两个权威信号源的并集：
+//    停止按钮 DOM 旗标（document.body.dataset.generating，ST/TT 同源，重掷/
+//    续写/群成员/借道 Generate 的生成都会点亮）与未闭合的 generation_started
+//    事件（带超时自愈）。不使用 ctx.streamingProcessor：插件持有的是加载时的
+//    一次性 getContext() 快照，该字段指望不上。也不把「带 MVU 特征的 fetch 在
+//    飞」当忙碌信号：正文替换与填表请求的 body 本就会嵌进含 <UpdateVariable>
+//    的正文，被特征命中，TT 实测会把整条数据库后处理排进追踪前面、拖出约两
+//    分钟延迟。MVU 额外模型解析的等待仍由既有兼容门控负责（TT 走带停止按钮的
+//    Generate 管线，dataset 信号同样会覆盖它这一程）；兼容开关语义原样不变。
+// 2. 正文替换会把毫秒时间戳 `_acu_last_optimized_at` 写进该楼层的 extra——
+//    shujuku 与 shujuku-rebuild 皆然，只有正文替换写它、随消息持久化、跨页面
+//    重载有效。楼层已有追踪回执、且该时间戳晚于回执时，正文差异就是替换改写：
+//    就地重锚签名、不重发请求（恒开、无提示）。手动编辑、重掷、续写、换楼层都
+//    不会盖出这个时间戳，照常走追踪路径；若宿主事件计数之类的内存态一律不作为
+//    判据（重载即归零，会把编辑后的合法改动误判成「无痕」而吞掉）。将来若出现
+//    不打此标记的其他静默写回者，宁可多追一轮也不漏，方向安全。
+
+const HOST_BUSY_STALE_MS_KEY = '__bs_biotracker_host_busy_stale_ms__';
+/** 两个数据库正文替换落库时在楼层 extra 上盖的毫秒时间戳（唯一写者） */
+const CONTENT_REPLACEMENT_MARK_KEY = '_acu_last_optimized_at';
+
+const hostRunState = {
+  listenersInstalled: false,
+  generationDepth: 0,
+  generationBusySince: 0,
+};
+export const __hostRunStateForTest = hostRunState;
+// 与 MVU 门控同法：挂到全局方便在真实宿主的 console 里排查触发问题
+globalThis.__bs_biotracker_debug_host_run__ = hostRunState;
+
+function resolveHostEventName(ctx, typeKey, fallback) {
+  const types = ctx?.eventTypes || ctx?.event_types;
+  const resolved = types?.[typeKey];
+  return typeof resolved === 'string' && resolved ? resolved : fallback;
+}
+
+function markHostGenerationStart() {
+  hostRunState.generationDepth += 1;
+  if (hostRunState.generationDepth === 1) hostRunState.generationBusySince = Date.now();
+}
+
+function markHostGenerationEnd() {
+  // 宿主 GENERATION_ENDED 只在停止按钮真的从显示转隐藏时发、嵌套不去重：一轮群里
+  // 连续生成可能 STARTED 多次、ENDED 一次。把 ended/stopped 当作「宿主自认生成
+  // 已全部结束」的权威信号直接清空深度（dataset 旗标仍是独立信号，真在飞时
+  // 不会假清空），否则计数只增不减会把追踪卡死到看门狗上限。
+  hostRunState.generationDepth = 0;
+  hostRunState.generationBusySince = 0;
+}
+
+export function installHostRunWatchers(ctx) {
+  if (hostRunState.listenersInstalled) return;
+  const source = ctx?.eventSource;
+  if (!source || typeof source.on !== 'function') return;
+  // 无论订到第几个都标记为已安装、不再重试：宿主 eventSource.on 实际不会抛，
+  // 万一抛了也只可能缺一腿，重复叠加监听反而会把深度计数订乱
+  hostRunState.listenersInstalled = true;
+  try {
+    source.on(resolveHostEventName(ctx, 'GENERATION_STARTED', 'generation_started'), markHostGenerationStart);
+    source.on(resolveHostEventName(ctx, 'GENERATION_STOPPED', 'generation_stopped'), markHostGenerationEnd);
+    source.on(resolveHostEventName(ctx, 'GENERATION_ENDED', 'generation_ended'), markHostGenerationEnd);
+  } catch (error) {
+    console.warn('[BS BioTracker] 無法訂閱宿主生成事件', error);
+  }
+}
+
+function hostDatasetGenerating() {
+  try {
+    return globalThis.document?.body?.dataset?.generating === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 宿主主生成是否仍在进行（不该发追踪）：停止按钮 DOM 旗标与未闭合的
+ * generation started 两源并集，任一即忙；事件源带超时自愈。
+ * 特意不含任何「插件级 fetch 观测」信号：数据库正文替换/填表的请求体常嵌着
+ * 含 <UpdateVariable> 的正文，会被 MVU 特征误命中，把它们当作忙碌会把追踪
+ * 排到整条数据库后处理之后（TT 实测拖出约两分钟的延迟）。MVU 额外模型解析
+ * 的等待由既有的兼容门控 shouldWaitForMvuExtraAnalysis 负责（TT 上它走带停止
+ * 按钮的 Generate 管线，dataset 信号同样会覆盖其在飞阶段），兼容开关语义不动。
+ */
+export function isHostGenerationBusy(ctx) {
+  if (hostDatasetGenerating()) return true;
+  if (hostRunState.generationDepth > 0) {
+    const staleMs = Number(globalThis[HOST_BUSY_STALE_MS_KEY]) || 600000;
+    if (Date.now() - hostRunState.generationBusySince > staleMs) {
+      // 漏收 ended（页面切换/宿主早隐藏停止按钮）时不能永久卡死追踪
+      hostRunState.generationDepth = 0;
+      hostRunState.generationBusySince = 0;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** 楼层上正文替换盖的毫秒时间戳；没盖过返回 0。 */
+function readReplacementMarkMs(message) {
+  const raw = Number(message?.extra?.[CONTENT_REPLACEMENT_MARK_KEY]);
+  return Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+function getFloorAnchorFields(message) {
+  return {
+    anchorVersion: 1,
+    // ST/TT 的消息对象没有 id 字段（只有 MVU 的 setChatMessages 形参叫 message_id，
+    // 且那是传参不是落库字段）：有就比对、没有就跳过该项，绝不能以它为必要条件
+    tailMessageId: message?.id === undefined || message?.id === null
+      ? (message?.message_id === undefined || message?.message_id === null ? '' : String(message.message_id))
+      : String(message.id),
+    tailSwipeId: message?.swipe_id === undefined || message?.swipe_id === null ? '' : String(message.swipe_id),
+    tailName: String(message?.name || ''),
+  };
+}
+
+function sameFloorIdentity(stamp, currentFloor) {
+  if (!currentFloor) return false;
+  // id 两边都有才比：都没有（ST/TT 真机常态）时不以此拒绝
+  const stampId = String(stamp?.tailMessageId || '');
+  const currentId = String(currentFloor.id ?? currentFloor.message_id ?? '');
+  if (stampId && currentId && stampId !== currentId) return false;
+  if (String(currentFloor.swipe_id ?? '') !== String(stamp?.tailSwipeId ?? '')) return false;
+  // 旧快照没有 tailName 时跳过该项（v1 锚点继续有效，不做版本迁移）
+  const stampName = String(stamp?.tailName || '');
+  if (stampName && String(currentFloor.name || '') !== stampName) return false;
+  return true;
+}
+
+/** 正文替换时间戳晚于锚点时刻 = 之后确有替换写回（跨重载有效，不依赖内存计数）。 */
+function isReplacementAfter(anchorAtMs, currentFloor) {
+  if (!anchorAtMs) return false;
+  return readReplacementMarkMs(currentFloor) > Number(anchorAtMs);
+}
+
+function findReplacementAnchorSnapshot(chatState, count) {
+  const snapshots = Array.isArray(chatState?.snapshots) ? chatState.snapshots : [];
+  for (let index = snapshots.length - 1; index >= 0; index -= 1) {
+    const snapshot = snapshots[index];
+    const reason = String(snapshot?.reason || '');
+    if (reason !== 'tracker' && reason !== 'silent_replace') continue;
+    if (Number(snapshot?.messageCount) !== count) continue;
+    return snapshot;
+  }
+  return null;
+}
+
+/**
+ * 数据库正文替换的静默吸收：追踪回执所在楼层带着晚于回执的替换时间戳时，
+ * 就地重锚快照与 lastProcessedSignature，下一轮不再发出追踪请求。
+ * 返回 true = 本轮轮询已被吸收。恒生效、无开关、无提示。
+ */
+export function tryAdoptSilentTailReplacement(ctx, settings, chatState) {
+  const chat = getHostChat(ctx);
+  const count = chat.length;
+  if (count <= 0) return false;
+  const last = chat[count - 1];
+  if (!last || last.is_user) return false;
+  if (!readReplacementMarkMs(last)) return false;
+  const currentSignature = buildSignature(ctx, count);
+  if (currentSignature && currentSignature === String(chatState?.lastProcessedSignature || '')) return false;
+  const snapshot = findReplacementAnchorSnapshot(chatState, count);
+  if (!snapshot || Number(snapshot.anchorVersion) !== 1) return false;
+  if (!sameFloorIdentity(snapshot, last)) return false;
+  if (!isReplacementAfter(snapshot.createdAt, last)) return false;
+  if (isHostGenerationBusy(ctx)) return false;
+  recordChatStateSnapshot(ctx, chatState, {
+    messageCount: count,
+    reason: 'silent_replace',
+    ...getFloorAnchorFields(last),
+  });
+  chatState.lastProcessedSignature = currentSignature;
+  saveSettings(ctx);
+  console.debug('[BS BioTracker] 偵測到正文替換回寫（楼层带替换戳记且晚于追踪回执），已重新锚定，未重發請求');
+  return true;
 }
 
 function normalizeWorldbookMode(value) {
@@ -1246,6 +1429,10 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   const attemptedSignature = buildSignature(ctx, messageIndex + 1);
   chatState.lastAttemptedSignature = attemptedSignature;
   saveSettings(ctx);
+  // 记下发出请求那一刻楼层的样子与时刻：返回时正文若有变化，用它区分
+  // 「重掷/编辑/删楼的合法改动」与「正文替换的静默改写（带替换戳记）」
+  const preCallFloorStamp = getFloorAnchorFields(chat[messageIndex]);
+  const preCallAtMs = Date.now();
   const systemPrompt = buildTrackerSystemPrompt(settings.systemPrompt || DEFAULT_SYSTEM_PROMPT, settings.registryDescriptionGuides || null, payload);
   recordTrackerRequestDebug(systemPrompt, payload);
   const rawResult = await callOpenAICompatible(
@@ -1266,7 +1453,16 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   } catch (error) {
     console.warn('[BS BioTracker] 分析后刷新聊天视图失败，改用现有视图比对', error);
   }
-  if (buildSignature(ctx, messageIndex + 1) !== attemptedSignature) {
+  const postCallSignature = buildSignature(ctx, messageIndex + 1);
+  // 在飞期间正文被改写的三种可能按「楼层带晚于发出时刻的替换戳记」一笔判定：
+  // 命中即正文替换（分析对象仍是替换前正文，结果对剧情有效）——沿用结果、
+  // 就地重锚，不作废重跑；重掷/编辑/删楼不会盖出戳记，照旧作废整份结果。
+  const silentReplacementDuringRun = postCallSignature !== attemptedSignature
+    && getHostChat(ctx).length === messageIndex + 1
+    && sameFloorIdentity(preCallFloorStamp, getHostChat(ctx)[messageIndex])
+    && isReplacementAfter(preCallAtMs, getHostChat(ctx)[messageIndex])
+    && !isHostGenerationBusy(ctx);
+  if (postCallSignature !== attemptedSignature && !silentReplacementDuringRun) {
     console.warn('[BS BioTracker] 该消息在分析期间被修改或删除，本次结果已作废');
     chatState.lastRawResult = {
       message: '该消息在分析期间被修改或删除，本次结果已作废，未写入任何状态。',
@@ -1277,14 +1473,21 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
     saveSettings(ctx);
     return { discarded: true };
   }
+  if (silentReplacementDuringRun) {
+    console.debug('[BS BioTracker] 追踪进行期间正文被静默替换，沿用本次结果并改按替换后正文重新锚定');
+  }
 
   const result = normalizeTrackerResult(rawResult);
   result.character_check_coverage = buildCharacterCheckCoverage(payload.tracked_females, result.character_checks);
   applyToolCallsResult(ctx, result);
-  chatState.lastProcessedSignature = attemptedSignature;
+  chatState.lastProcessedSignature = silentReplacementDuringRun ? postCallSignature : attemptedSignature;
   chatState.lastFailedSignature = '';
   chatState.lastFailedChatSignature = '';
-  recordChatStateSnapshot(ctx, chatState, { messageCount: messageIndex + 1, reason: 'tracker' });
+  recordChatStateSnapshot(ctx, chatState, {
+    messageCount: messageIndex + 1,
+    reason: 'tracker',
+    ...getFloorAnchorFields(getHostChat(ctx)[messageIndex]),
+  });
   saveSettings(ctx);
   return { discarded: false, triggered: true };
 }
@@ -1345,6 +1548,10 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     deps.renderStatusPanel(ctx);
     return { skipped: true, reason: 'luker_multi_agent_manual' };
   }
+  if (reason === 'poll' && isHostGenerationBusy(ctx)) {
+    // 主连接没说完话就绝不追踪：从根上消灭「开始吐字时抢发一轮」
+    return { skipped: true, reason: 'host_generation_in_flight' };
+  }
   if (reason === 'poll') {
     const agentBarrier = await getHostAgentRunBarrier(ctx, lastMessage);
     if (agentBarrier.state === 'pending') {
@@ -1376,6 +1583,10 @@ export async function runTracker(ctx, deps, reason = 'manual') {
   }
   if (reason === 'poll' && shouldWaitForMvuExtraAnalysis(ctx, settings)) {
     return { skipped: true, reason: 'waiting_mvu_extra_analysis' };
+  }
+  if (reason === 'poll' && tryAdoptSilentTailReplacement(ctx, settings, chatState)) {
+    // 正文替换的无痕改写：静默重锚，不发请求也不弹任何提示
+    return { skipped: true, reason: 'silent_tail_replacement' };
   }
   if (reason === 'poll' && isFailedAutoRetryBlocked(ctx, chatState)) {
     return { skipped: true, reason: 'failed_message_blocked' };
@@ -1451,6 +1662,11 @@ export function resetPoller(ctx, deps) {
   if (globalThis[POLL_RUNTIME_KEY]) clearInterval(globalThis[POLL_RUNTIME_KEY]);
   // 尽早安装 MVU 生成请求钩子，避免正文后第一时间启动的 MVU 请求漏观测
   installMvuFetchHook();
+  // 变量更新结束事件监听同样必须提前装：忙碌闸门会跳过解析期间的门控评估，
+  // 若等第一次评估才订事件，mag_variable_update_ended 早已错过、只能靠宽限干等
+  installMvuGateListener(ctx);
+  // 宿主 generation/编辑/swipe 事件监听同样只装一次：忙碌闸门与静默替换判定都靠它
+  installHostRunWatchers(ctx);
   const settings = getSettings(ctx);
   globalThis[POLL_RUNTIME_KEY] = setInterval(() => {
     deps.updateClock(settings);

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -152,8 +152,7 @@ export function getMvuSettings(ctx) {
   return null;
 }
 
-export function isMvuExtraAnalysisEnabled(ctx, settings) {
-  if (settings.mvuExtraAnalysisCompat === false) return false;
+export function isMvuExtraAnalysisEnabled(ctx, _settings) {
   const mvuSettings = getMvuSettings(ctx);
   if (!mvuSettings) return false;
   if (mvuSettings.更新方式 !== '额外模型解析') return false;
@@ -280,8 +279,7 @@ export function installMvuFetchHook() {
   mvuGateState.fetchHooked = true;
 }
 
-export function shouldWaitForMvuExtraAnalysis(ctx, settings) {
-  if (settings.mvuExtraAnalysisCompat === false) return false;
+export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
   const chat = getHostChat(ctx);
   const last = chat[chat.length - 1];
   // after_user 等时机下 MVU 的解析早已完成，无需等待

--- a/settings.html
+++ b/settings.html
@@ -239,14 +239,6 @@
             </div>
 
             <div class="settings_section">
-              <div class="bs-bt-setting-toggle-row">
-                <input id="bs-bt-mvu-extra-analysis-compat" type="checkbox" />
-                <label for="bs-bt-mvu-extra-analysis-compat">MVU 额外模型解析兼容(等待变量更新完成后再追踪)</label>
-              </div>
-              <small>检测到 MVU 变量框架开启「额外模型解析」时，延迟追踪请求到本轮变量更新结束后再发送，避免与 MVU 的更新请求重复消耗额度。</small>
-            </div>
-
-            <div class="settings_section">
               <label for="bs-bt-trigger">触发时机</label>
               <select id="bs-bt-trigger" class="text_pole">
                 <option value="after_ai">after_ai</option>

--- a/tests/host_generation_busy.test.mjs
+++ b/tests/host_generation_busy.test.mjs
@@ -1,0 +1,207 @@
+// 主生成忙碌闸门回归：串流（含 MVU 额外解析在飞）期间绝不发出追踪请求。
+//
+// 使用者在 TT 实测回报：開異步追蹤 + MVU 額外模型解析時，「主連接刚开始吐字」就会
+// 被追一轮。根因是宿主串流期间按 chunk 把半成品写进 mes（首帧还是 '...' 占位），
+// chunk 间隙一超过 settle 窗就被误判成说完。修法是轮询先查宿主忙碌态，忙则整轮跳过。
+import assert from 'node:assert/strict';
+import test, { afterEach } from 'node:test';
+
+import * as state from '../scripts/state.js';
+import {
+  runTracker,
+  isHostGenerationBusy,
+  installHostRunWatchers,
+  __hostRunStateForTest,
+  __mvuGateStateForTest,
+} from '../scripts/tracker.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const AFTER_AI_SETTLE_MS = 1400;
+const sleepPastSettle = () => new Promise((resolve) => { setTimeout(resolve, AFTER_AI_SETTLE_MS + 200); });
+
+afterEach(() => {
+  if (ORIGINAL_FETCH === undefined) delete globalThis.fetch;
+  else globalThis.fetch = ORIGINAL_FETCH;
+  delete globalThis.SillyTavern;
+  delete globalThis.toastr;
+  delete globalThis.document;
+  delete globalThis.Mvu;
+  delete globalThis.__bs_biotracker_host_busy_stale_ms__;
+  delete globalThis.__bs_biotracker_host_mvu_busy_max_ms__;
+});
+
+function makeFakeEventBus() {
+  const handlers = new Map();
+  return {
+    on(name, handler) {
+      if (!handlers.has(name)) handlers.set(name, []);
+      handlers.get(name).push(handler);
+    },
+    emit(name, ...args) {
+      (handlers.get(name) || []).forEach((handler) => handler(...args));
+    },
+  };
+}
+
+function resetRunState(ctx) {
+  const run = __hostRunStateForTest;
+  run.listenersInstalled = false;
+  run.generationDepth = 0;
+  run.generationBusySince = 0;
+  __mvuGateStateForTest.generateInFlight = 0;
+  if (ctx?.eventSource) installHostRunWatchers(ctx);
+}
+
+function makeCtx(overrides = {}) {
+  const ctx = {
+    chatId: 'busy-chat',
+    chat: [{ id: 1, is_user: false, name: 'Alice', mes: 'previous reply', swipe_id: 0 }],
+    extensionSettings: {},
+    saveSettingsDebounced() {},
+    eventSource: makeFakeEventBus(),
+    eventTypes: {
+      GENERATION_STARTED: 'generation_started',
+      GENERATION_STOPPED: 'generation_stopped',
+      GENERATION_ENDED: 'generation_ended',
+    },
+    ...overrides,
+  };
+  globalThis.SillyTavern = { getContext: () => ctx };
+  const settings = state.getSettings(ctx);
+  settings.enabled = true;
+  settings.triggerTiming = 'after_ai';
+  settings.apiUrl = 'https://example.invalid/v1';
+  settings.apiKey = 'k';
+  settings.model = 'test-model';
+  state.getChatState(ctx, settings).characters['艾拉'] = {
+    name: '艾拉', initialized: true, profile: { base: {} },
+  };
+  const counter = { requests: 0 };
+  globalThis.fetch = async () => {
+    counter.requests += 1;
+    return {
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({ choices: [{ message: { content: JSON.stringify({ tool_calls: [] }) } }] });
+      },
+    };
+  };
+  resetRunState(ctx);
+  return { ctx, counter };
+}
+
+const deps = { renderStatusPanel() {}, updateMainFlowPrompt() {} };
+
+function setGenerating(value) {
+  globalThis.document = value === null
+    ? { body: { dataset: {} } }
+    : { body: { dataset: { generating: value ? 'true' : 'false' } } };
+}
+
+test('宿主的停止按钮旗标亮着时，即便内容早已稳定也不发追踪', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+
+  ctx.chat.push({ id: 2, is_user: true, name: 'User', mes: 'my input' });
+  ctx.chat.push({ id: 3, is_user: false, name: 'Alice', mes: '开头几个字', swipe_id: 0 });
+  // 串流刚开始：宿主把半截正文写进来后就卡在两个 chunk 的间隙里
+  setGenerating(true);
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 0, '主生成在飞时不该发追踪');
+
+  setGenerating(false);
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 1, '主生成结束且内容稳定后恰好补发一次');
+});
+
+test('streamingProcessor 不再作为信号源（getContext 一次性快照不可靠）', () => {
+  const probeCtx = { chat: [], extensionSettings: {}, saveSettingsDebounced() {} };
+  setGenerating(false);
+  probeCtx.streamingProcessor = { isFinished: false };
+  assert.equal(isHostGenerationBusy(probeCtx), false, '该字段是加载时的旧引用，不该据此冻结追踪');
+});
+
+test('generation_started / ended 事件对驱动忙碌态；漏收 ended 时看门狗放行', async () => {
+  const { ctx } = makeCtx();
+  setGenerating(false);
+  assert.equal(isHostGenerationBusy(ctx), false);
+  ctx.eventSource.emit('generation_started');
+  assert.equal(isHostGenerationBusy(ctx), true, '收到 started 就该视为在飞');
+  ctx.eventSource.emit('generation_ended');
+  assert.equal(isHostGenerationBusy(ctx), false, 'ended 清计数');
+
+  // 群組/工具嵌套会多次 started、只在最后一并 ended；若 ended 全程漏收，
+  // 卡死追踪的时间必须被 staleness 上限截断（测试注入 60ms）
+  globalThis.__bs_biotracker_host_busy_stale_ms__ = 60;
+  ctx.eventSource.emit('generation_started');
+  assert.equal(isHostGenerationBusy(ctx), true);
+  await new Promise((resolve) => { setTimeout(resolve, 90); });
+  assert.equal(isHostGenerationBusy(ctx), false, '超上限后自愈');
+  // stopped 也是权威结束信号
+  ctx.eventSource.emit('generation_started');
+  ctx.eventSource.emit('generation_stopped');
+  assert.equal(isHostGenerationBusy(ctx), false);
+});
+
+test('嵌套生成只收到一次 ended 时，深度整体清空而非残留', () => {
+  const { ctx } = makeCtx();
+  setGenerating(false);
+  ctx.eventSource.emit('generation_started');
+  ctx.eventSource.emit('generation_started');
+  ctx.eventSource.emit('generation_started');
+  ctx.eventSource.emit('generation_ended');
+  assert.equal(isHostGenerationBusy(ctx), false, '宿主自认结束事件权威：清空全部残留深度');
+});
+
+test('MVU 在飞信号不再进入忙碌闸门（修复两分钟延迟的回归点）', () => {
+  // 旧实现把「带 MVU 特征的 fetch 在飞 / isDuringExtraAnalysis」当忙碌信号，而
+  // 数据库正文替换/填表请求的 body 也含 <UpdateVariable>，被误命中后整条数据库
+  // 后处理排到追踪前面，TT 实测拖出约两分钟。现在忙碌只看宿主自身信号。
+  const { ctx } = makeCtx();
+  setGenerating(false);
+  globalThis.Mvu = { isDuringExtraAnalysis: () => true };
+  assert.equal(isHostGenerationBusy(ctx), false, 'MVU 标志不该冻结忙碌闸门');
+  globalThis.Mvu = undefined;
+  __mvuGateStateForTest.generateInFlight = 3;
+  assert.equal(isHostGenerationBusy(ctx), false, '特征请求在飞也不该冻结忙碌闸门');
+  // 但真·宿主生成仍然要拦
+  __mvuGateStateForTest.generateInFlight = 0;
+  ctx.eventSource.emit('generation_started');
+  assert.equal(isHostGenerationBusy(ctx), true, '宿主 generation 在飞仍是忙碌');
+});
+
+test('串流中途到主+MVU 解析全部结束，整段只追踪一次', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+
+  // 使用者发送 → 宿主开始流式出字
+  ctx.chat.push({ id: 2, is_user: true, name: 'User', mes: '继续' });
+  setGenerating(true);
+  ctx.chat.push({ id: 3, is_user: false, name: 'Alice', mes: '...', swipe_id: 0 });
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 0);
+  await sleepPastSettle();
+  ctx.chat[2].mes = '出到一半的正文，后面还有';
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 0, '串流中途即使内容“稳定”了也不追');
+
+  // 主生成结束。数据库/MVU 的在飞特征请求由兼容门控 shouldWaitForMvuExtraAnalysis
+  // 处理（不再是忙碌闸门），这里验证它仍会挡住抢发、且整体只追踪一次
+  setGenerating(false);
+  ctx.chat[2].mes = '完整正文';
+  __mvuGateStateForTest.generateInFlight = 1;
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 0, '特征请求在飞时由兼容门控挡住，不抢发');
+  __mvuGateStateForTest.generateInFlight = 0;
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 1, '都结束后恰好一次');
+});

--- a/tests/host_generation_busy.test.mjs
+++ b/tests/host_generation_busy.test.mjs
@@ -48,6 +48,8 @@ function resetRunState(ctx) {
   run.listenersInstalled = false;
   run.generationDepth = 0;
   run.generationBusySince = 0;
+  run.mutSeq = 0;
+  run.ctxRef = null;
   __mvuGateStateForTest.generateInFlight = 0;
   if (ctx?.eventSource) installHostRunWatchers(ctx);
 }

--- a/tests/mvu_gate.test.mjs
+++ b/tests/mvu_gate.test.mjs
@@ -28,7 +28,7 @@ function makeCtx(overrides = {}) {
 }
 
 function makeSettings(overrides = {}) {
-  return { mvuExtraAnalysisCompat: true, ...overrides };
+  return { ...overrides };
 }
 
 function makeMvuSettings(overrides = {}) {
@@ -75,13 +75,15 @@ test('MVU 更新方式为随AI输出时不等待', () => {
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), false);
 });
 
-test('关闭兼容开关后即使 MVU 配置了额外解析也不等待', () => {
+test('兼容开关已移除：即使存档里残留关闭值，门控依然恒等待', () => {
   resetGate();
+  setDuring(false);
   const ctx = makeCtx({
     extensionSettings: { mvu_settings: makeMvuSettings() },
   });
-  assert.equal(isMvuExtraAnalysisEnabled(ctx, makeSettings({ mvuExtraAnalysisCompat: false })), false);
-  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings({ mvuExtraAnalysisCompat: false })), false);
+  // 旧存档的 mvuExtraAnalysisCompat: false 已不再被读取，恒开启
+  assert.equal(isMvuExtraAnalysisEnabled(ctx, makeSettings({ mvuExtraAnalysisCompat: false })), true);
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings({ mvuExtraAnalysisCompat: false })), true);
 });
 
 test('额外模型解析未开启自动请求时视为不等待', () => {

--- a/tests/mvu_gate.test.mjs
+++ b/tests/mvu_gate.test.mjs
@@ -1,4 +1,4 @@
-﻿// MVU 额外模型解析兼容门控测试：验证追踪请求在 MVU 变量更新结束前会被推迟。
+// MVU 额外模型解析兼容门控测试：验证追踪请求在 MVU 变量更新结束前会被推迟。
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -6,6 +6,7 @@ import {
   __mvuGateStateForTest,
   getMainflowContextSnapshot,
   installMvuFetchHook,
+  installMvuGateListener,
   isMvuExtraAnalysisEnabled,
   isMvuExtraAnalysisRequest,
   shouldWaitForMvuExtraAnalysis,
@@ -45,7 +46,6 @@ function resetGate() {
   __mvuGateStateForTest.pendingKey = '';
   __mvuGateStateForTest.pendingContentKey = '';
   __mvuGateStateForTest.pendingSince = 0;
-  __mvuGateStateForTest.announcedChatKey = '';
   // fetchHooked/eventInstalled 不重置：钩子只装一次，避免嵌套包装
   __mvuGateStateForTest.generateInFlight = 0;
   __mvuGateStateForTest.lastGenerateStartedAt = 0;
@@ -435,4 +435,97 @@ test('mainflow 状态 JSON 转义闭合标签与换行（安全审查 P1 注入�
   // 包裹标签本身仍在（转义只作用于 JSON 内容，不破坏结构）
   assert.ok(prompt.includes('<bs_biotracker>'), '起始包裹标签应保留');
   assert.ok(prompt.trimEnd().endsWith('</bs_biotracker>'), '结束包裹标签应保留在末尾');
+});
+
+// ---- TT 实测两分钟延迟的回归点 ----
+// 数据库正文替换/填表的请求体嵌着含 <UpdateVariable>、json_patch 字样的正文，
+// 会被 fetch 特征误命中。新版 MVU 有 isDuringExtraAnalysis 全局权威时，门控
+// 不得再采信特征计数，否则追踪会串行等完数据库整条后处理管线。
+test('MVU 全局可得时不采信 fetch 特征在飞（正文替换/填表误命中不连锁）', () => {
+  resetGate();
+  setDuring(false); // 全局权威：本轮 MVU 解析已经结束
+  const ctx = makeCtx({
+    extensionSettings: { mvu_settings: makeMvuSettings() },
+  });
+  const settings = makeSettings();
+  __mvuGateStateForTest.generateInFlight = 5; // 数据库请求被特征误命中
+  // 首次评估进入宽限期等待（此时还没有任何结束信号）
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
+  __mvuGateStateForTest.pendingSince = Date.now() - MVU_EXTRA_WAIT_GRACE_MS - 1000;
+  assert.equal(
+    shouldWaitForMvuExtraAnalysis(ctx, settings),
+    false,
+    '全局说不忙就放行，不能被误命中的特征计数拖到 120 秒上限',
+  );
+});
+
+test('替换改写不重启宽限：等待起点保持，宽限到期即放行', () => {
+  resetGate();
+  setDuring(false);
+  const ctx = makeCtx({
+    extensionSettings: { mvu_settings: makeMvuSettings() },
+  });
+  const settings = makeSettings();
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
+  const pendingSince = __mvuGateStateForTest.pendingSince;
+  // 正文替换落库：同楼层改写 + 戳记晚于等待起点
+  const tail = ctx.chat[ctx.chat.length - 1];
+  tail.mes = '变量渲染后的正文';
+  tail.extra = { _acu_last_optimized_at: Date.now() };
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
+  assert.equal(__mvuGateStateForTest.pendingSince, pendingSince, '替换落库不得重排等待起点');
+  // 宽限到期即放行（旧逻辑会被替换续杯、继续等待）
+  __mvuGateStateForTest.pendingSince = Date.now() - MVU_EXTRA_WAIT_GRACE_MS - 1000;
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('结束事件新鲜但替换先落地：有晚于事件的替换戳即放行，不等宽限', () => {
+  resetGate();
+  setDuring(false);
+  const ctx = makeCtx({
+    extensionSettings: { mvu_settings: makeMvuSettings() },
+  });
+  const settings = makeSettings();
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
+  // 结束事件记录的是替换前的指纹
+  const roundKey = `${ctx.chatId}:${ctx.chat.length}:assistant:${ctx.chat[ctx.chat.length - 1].id}`;
+  __mvuGateStateForTest.lastEndedKey = roundKey;
+  __mvuGateStateForTest.lastEndedContentKey = buildSignature(ctx, ctx.chat.length);
+  __mvuGateStateForTest.lastEndedAt = Date.now() - 50;
+  // 替换在事件之后落库
+  const tail = ctx.chat[ctx.chat.length - 1];
+  tail.mes = '替换后正文';
+  tail.extra = { _acu_last_optimized_at: Date.now() };
+  assert.equal(
+    shouldWaitForMvuExtraAnalysis(ctx, settings),
+    false,
+    'MVU 产物已落定（戳晚于结束事件），应立即在最终正文上放行',
+  );
+}); 
+
+test('监听提前安装时，结束事件一到即记录、门控立刻放行（不等宽限期）', () => {
+  resetGate();
+  setDuring(false);
+  // 重置安装标志，用独立 eventSource 验证「先订监听、后发事件」的时序
+  __mvuGateStateForTest.eventInstalled = false;
+  const handlers = new Map();
+  const eventSource = {
+    on(name, fn) { handlers.set(name, [fn]); },
+    emit(name) { (handlers.get(name) || []).forEach((fn) => fn()); },
+  };
+  const ctx = makeCtx({
+    eventSource,
+    extensionSettings: { mvu_settings: makeMvuSettings() },
+  });
+  const settings = makeSettings();
+  installMvuGateListener(ctx); // 相当于 resetPoller 的提前安装时机
+  assert.equal(handlers.size, 1, '事件名解析自 Mvu.events 或字面量，应挂上监听');
+  // 宿主/DB 在忙碌阶段不会评估门控；解析结束事件先于任何评估发生
+  eventSource.emit('mag_variable_update_ended');
+  assert.equal(
+    shouldWaitForMvuExtraAnalysis(ctx, settings),
+    false,
+    '错过的结束事件已被记录，评估当轮即放行',
+  );
+  __mvuGateStateForTest.eventInstalled = false;
 });

--- a/tests/silent_text_replacement.test.mjs
+++ b/tests/silent_text_replacement.test.mjs
@@ -97,6 +97,7 @@ function makeCtx() {
       GENERATION_ENDED: 'generation_ended',
       MESSAGE_EDITED: 'message_edited',
       MESSAGE_SWIPED: 'message_swiped',
+      MESSAGE_UPDATED: 'message_updated',
     },
   };
   globalThis.SillyTavern = { getContext: () => ctx };
@@ -437,5 +438,42 @@ test('页面重载（计数归零）后手动编辑：持久化计数回填仍�
   await sleepPastSettle();
   await runTracker(ctx, deps, 'poll');
   assert.equal(counter.requests, 2, '重载后的编辑不得被静默吞掉');
+});
+
+test('ts_edit 形状的程序化编辑（只发 MESSAGE_UPDATED）：否决吸收，照常追踪', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+
+  await sleep(20);
+  simulateReplacement(ctx.chat[2], '完整正文（变量渲染后）');
+  // 酒馆助手 ts_edit / JS-Runner 改正文：只发 message_updated，不发 message_edited
+  ctx.eventSource.emit('message_updated');
+  ctx.chat[2].mes = '完整正文（变量渲染后）+ 脚本改写';
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, 'MESSAGE_UPDATED 编辑必须同样否决吸收');
+});
+
+test('编辑事件先于任何轮询评估到达：hydrate 先行，持久化计数不被小值覆写', async () => {
+  const { ctx, settings } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  // 先来一次编辑，让回执锚点的计数不为 0（hydrate 缺失时覆写 bug 才有鉴别力）
+  ctx.eventSource.emit('message_edited');
+  await trackOneReply(ctx);
+  const persistedAtReceipt = Number(settings.hostMutSeqCounter);
+  assert.ok(persistedAtReceipt >= 1, '回执应持久化非零计数');
+
+  // 模拟重载：内存归零、持久值保留；「首次轮询之前」来了编辑事件——
+  // bump 若不先 hydrate，会把持久值覆成 1，锚点比对（快照=持久值）随即失效
+  __hostRunStateForTest.mutSeq = 0;
+  ctx.eventSource.emit('message_edited');
+  assert.equal(__hostRunStateForTest.mutSeq, persistedAtReceipt + 1,
+    'bump 必须先回填持久计数再自增');
+  assert.equal(Number(settings.hostMutSeqCounter), persistedAtReceipt + 1,
+    '持久计数只前进不后退');
 });
 

--- a/tests/silent_text_replacement.test.mjs
+++ b/tests/silent_text_replacement.test.mjs
@@ -45,6 +45,8 @@ function resetAllGates(ctx) {
   run.listenersInstalled = false;
   run.generationDepth = 0;
   run.generationBusySince = 0;
+  run.mutSeq = 0;
+  run.ctxRef = null;
   const gate = __mvuGateStateForTest;
   gate.lastEndedKey = '';
   gate.lastEndedContentKey = '';
@@ -93,6 +95,8 @@ function makeCtx() {
       GENERATION_STARTED: 'generation_started',
       GENERATION_STOPPED: 'generation_stopped',
       GENERATION_ENDED: 'generation_ended',
+      MESSAGE_EDITED: 'message_edited',
+      MESSAGE_SWIPED: 'message_swiped',
     },
   };
   globalThis.SillyTavern = { getContext: () => ctx };
@@ -335,3 +339,103 @@ test('真机回归：无 id 楼层（ST/TT 实际形状）同样吸收；message
   // lenient 规则只在两边都有且不等时拒绝，单边出现不拒绝，仍吸收
   assert.equal(counter.requests, 1, '单边 message_id 不应破坏吸收');
 });
+
+// ---- 评审点名：替换戳与编辑的绑定 ----
+// 「追踪完成 → 替换 → 下次轮询吸收之前用户手动编辑」：编辑不动替换戳，
+// 若只看「戳晚于回执」会把编辑一起吞掉。编辑事件计数与戳值前进必须同时成立。
+
+test('替换落库后、吸收之前用户手动编辑：编辑事件否决吸收，照常追踪', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+
+  await sleep(20);
+  simulateReplacement(ctx.chat[2], '完整正文（变量渲染后）');
+  // 下一次轮询之前用户手改（宿主发 message_edited）
+  ctx.eventSource.emit('message_edited');
+  ctx.chat[2].mes = '完整正文（变量渲染后）+ 用户微调';
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '替换后的手动编辑不得被吸收');
+});
+
+test('请求在飞时先替换、再手动修改：编辑事件否决沿用，作废重跑', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+
+  let releaseFetch;
+  let holdNextFetch = true;
+  globalThis.fetch = async () => {
+    counter.requests += 1;
+    if (holdNextFetch) {
+      holdNextFetch = false;
+      await new Promise((resolve) => { releaseFetch = resolve; });
+    }
+    return okResponse();
+  };
+
+  ctx.chat.push({ is_user: true, name: 'User', mes: '继续' });
+  await runTracker(ctx, deps, 'poll');
+  ctx.chat.push({ is_user: false, name: 'Alice', mes: '完整正文', swipe_id: 0 });
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  const runPromise = runTracker(ctx, deps, 'poll');
+  await sleep(50);
+
+  await sleep(20);
+  simulateReplacement(ctx.chat[2], '完整正文（变量渲染后）');
+  ctx.eventSource.emit('message_edited');
+  ctx.chat[2].mes = '完整正文（变量渲染后）+ 用户微调';
+  releaseFetch();
+  await runPromise;
+  assert.equal(counter.requests, 1, '在飞这轮不作废即不重发');
+  const chatState = chatStateOf(ctx);
+  assert.notEqual(chatState.lastProcessedSignature, buildSignature(ctx, 3), '带编辑的改写必须作废，不得推进回执');
+
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '作废后下一轮照常补追（编辑内容被追踪到）');
+});
+
+test('吸收之后手动编辑：戳值未前进否决吸收，照常追踪', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+  await replaceTail(ctx, '完整正文（变量渲染后）');
+  assert.equal(counter.requests, 1, '纯替换先被吸收');
+
+  await sleep(20);
+  ctx.chat[2].mes = '用户在吸收之后手改';
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '吸收后编辑（戳不前进）必须重追踪');
+});
+
+test('页面重载（计数归零）后手动编辑：持久化计数回填仍能否决吸收', async () => {
+  const { ctx, counter, settings } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+
+  await sleep(20);
+  simulateReplacement(ctx.chat[2], '完整正文（变量渲染后）');
+  // 模拟重载：内存计数归零，持久化计数（回执时写入）保留；回填后用户编辑 → 前进
+  assert.ok(Number(settings.hostMutSeqCounter) >= 0, '回执应已持久化编辑计数');
+  __hostRunStateForTest.mutSeq = 0;
+  ctx.eventSource.emit('message_edited'); // 重载后的手动编辑
+  ctx.chat[2].mes = '完整正文（变量渲染后）+ 重载后手改';
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '重载后的编辑不得被静默吞掉');
+});
+

--- a/tests/silent_text_replacement.test.mjs
+++ b/tests/silent_text_replacement.test.mjs
@@ -1,0 +1,337 @@
+// 正文替换静默吸收回归：数据库经 setChatMessages 改写尾楼并盖 `_acu_last_optimized_at`
+// 时，追踪不得重发；没有该戳记的改写（手动编辑、其它静默写回者）一律照常追踪。
+// 判据特意不用内存事件计数——页面重载会让计数归零、把编辑误吞（评审 F1）。
+import assert from 'node:assert/strict';
+import test, { afterEach } from 'node:test';
+
+import * as state from '../scripts/state.js';
+import {
+  runTracker,
+  installHostRunWatchers,
+  __hostRunStateForTest,
+  __mvuGateStateForTest,
+} from '../scripts/tracker.js';
+import { buildSignature } from '../scripts/state.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const AFTER_AI_SETTLE_MS = 1400;
+const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+const sleepPastSettle = () => sleep(AFTER_AI_SETTLE_MS + 200);
+
+afterEach(() => {
+  if (ORIGINAL_FETCH === undefined) delete globalThis.fetch;
+  else globalThis.fetch = ORIGINAL_FETCH;
+  delete globalThis.SillyTavern;
+  delete globalThis.toastr;
+  delete globalThis.document;
+  delete globalThis.Mvu;
+});
+
+function makeFakeEventBus() {
+  const handlers = new Map();
+  return {
+    on(name, handler) {
+      if (!handlers.has(name)) handlers.set(name, []);
+      handlers.get(name).push(handler);
+    },
+    emit(name, ...args) {
+      (handlers.get(name) || []).forEach((handler) => handler(...args));
+    },
+  };
+}
+
+function resetAllGates(ctx) {
+  const run = __hostRunStateForTest;
+  run.listenersInstalled = false;
+  run.generationDepth = 0;
+  run.generationBusySince = 0;
+  const gate = __mvuGateStateForTest;
+  gate.lastEndedKey = '';
+  gate.lastEndedContentKey = '';
+  gate.lastEndedAt = 0;
+  gate.pendingKey = '';
+  gate.pendingContentKey = '';
+  gate.pendingSince = 0;
+  gate.generateInFlight = 0;
+  gate.sawGenerateThisRound = false;
+  gate.everSawMvuSignal = false;
+  if (ctx?.eventSource) installHostRunWatchers(ctx);
+}
+
+/** 数据库正文替换的真实形状：覆写 mes + 在 extra 盖毫秒戳 */
+function simulateReplacement(message, newText) {
+  message.mes = newText;
+  if (!message.extra || typeof message.extra !== 'object') message.extra = {};
+  message.extra._acu_last_optimized_at = Date.now();
+  message.extra._acu_original_content = message.extra._acu_original_content || newText;
+}
+
+function okResponse() {
+  return {
+    ok: true,
+    status: 200,
+    async text() {
+      return JSON.stringify({ choices: [{ message: { content: JSON.stringify({ tool_calls: [] }) } }] });
+    },
+  };
+}
+
+function makeCtx() {
+  const toasts = [];
+  globalThis.toastr = {
+    info: (msg, title) => { toasts.push(['info', msg, title]); },
+    success: (msg, title) => { toasts.push(['success', msg, title]); },
+    clear: () => {},
+  };
+  const ctx = {
+    chatId: 'silent-replace-chat',
+    chat: [{ is_user: false, name: 'Alice', mes: 'previous reply', swipe_id: 0 }],
+    extensionSettings: {},
+    saveSettingsDebounced() {},
+    eventSource: makeFakeEventBus(),
+    eventTypes: {
+      GENERATION_STARTED: 'generation_started',
+      GENERATION_STOPPED: 'generation_stopped',
+      GENERATION_ENDED: 'generation_ended',
+    },
+  };
+  globalThis.SillyTavern = { getContext: () => ctx };
+  const settings = state.getSettings(ctx);
+  settings.enabled = true;
+  settings.triggerTiming = 'after_ai';
+  settings.apiUrl = 'https://example.invalid/v1';
+  settings.apiKey = 'k';
+  settings.model = 'test-model';
+  state.getChatState(ctx, settings).characters['艾拉'] = {
+    name: '艾拉', initialized: true, profile: { base: {} },
+  };
+  const counter = { requests: 0 };
+  globalThis.fetch = async () => {
+    counter.requests += 1;
+    return okResponse();
+  };
+  resetAllGates(ctx);
+  return { ctx, counter, toasts, settings };
+}
+
+const deps = { renderStatusPanel() {}, updateMainFlowPrompt() {} };
+
+function chatStateOf(ctx) {
+  return state.getChatState(ctx, state.getSettings(ctx));
+}
+
+async function trackOneReply(ctx) {
+  ctx.chat.push({ is_user: true, name: 'User', mes: '继续' });
+  await runTracker(ctx, deps, 'poll'); // 使用者楼层只记 skip 快照
+  ctx.chat.push({ is_user: false, name: 'Alice', mes: '完整正文', swipe_id: 0 });
+  await runTracker(ctx, deps, 'poll'); // 建立 settle 基线
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll'); // 触发真正的一次追踪
+}
+
+async function replaceTail(ctx, text) {
+  await sleep(20); // 让替换戳记严格晚于回执时刻
+  simulateReplacement(ctx.chat[ctx.chat.length - 1], text);
+  await runTracker(ctx, deps, 'poll'); // settle 重新计时
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll'); // 吸收/重追踪发生在这里
+}
+
+test('带替换戳记的同楼层改写被静默吸收，不重发请求也不弹提示', async () => {
+  const { ctx, counter, toasts } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1, '一轮回复先追踪一次');
+  toasts.length = 0;
+
+  await replaceTail(ctx, '完整正文（变量渲染后）');
+  assert.equal(counter.requests, 1, '正文替换不得触发第二轮追踪');
+  assert.equal(toasts.filter((t) => String(t[1]).includes('追踪')).length, 0, '吸收过程必须全程静默');
+
+  const chatState = chatStateOf(ctx);
+  const last = chatState.snapshots[chatState.snapshots.length - 1];
+  assert.equal(last.reason, 'silent_replace');
+  assert.equal(last.messageCount, 3);
+  assert.equal(chatState.lastProcessedSignature, buildSignature(ctx, 3));
+
+  // 第二轮替换写回（shujuku-rebuild 在 ended 后还会复跑一次）
+  await replaceTail(ctx, '完整正文（变量渲染后 v2）');
+  assert.equal(counter.requests, 1, '连续多次替换逐次静默吸收');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 1, '吸收后长期保持静默');
+});
+
+test('页面重载后也无事件计数的世界：无戳记的内容改动（手动编辑）照常追踪', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+
+  // 手动编辑/任何不盖替换戳的改写——即使监听器全新装载（模拟重载）也必须重追踪
+  await sleep(20);
+  ctx.chat[2].mes = '使用者手改过的正文';
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '没有替换戳 => 不是正文替换 => 照常追踪');
+});
+
+test('swipe 变化（切抽卡）即便楼层带着旧替换戳也照常追踪', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+  simulateReplacement(ctx.chat[2], '完整正文（第一轮替换）');
+  ctx.chat[2].mes = '该楼的另一张抽卡结果';
+  ctx.chat[2].swipe_id = 1;
+  await sleep(20);
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, 'swipe 身份变化不能当作静默替换吸收');
+});
+
+test('请求在飞时替换落地（戳晚于发出）：沿用结果重锚，不作废重发', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+
+  let releaseFetch;
+  let holdNextFetch = true;
+  globalThis.fetch = async () => {
+    counter.requests += 1;
+    if (holdNextFetch) {
+      holdNextFetch = false;
+      await new Promise((resolve) => { releaseFetch = resolve; });
+    }
+    return okResponse();
+  };
+
+  ctx.chat.push({ is_user: true, name: 'User', mes: '继续' });
+  await runTracker(ctx, deps, 'poll');
+  ctx.chat.push({ is_user: false, name: 'Alice', mes: '完整正文', swipe_id: 0 });
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  const runPromise = runTracker(ctx, deps, 'poll');
+  await sleep(50); // 让 fetch 真正在飞
+
+  await sleep(20);
+  simulateReplacement(ctx.chat[2], '完整正文（变量渲染后）');
+  releaseFetch();
+  await runPromise;
+  assert.equal(counter.requests, 1, '在飞期间的替换不该引发第二轮请求');
+  const chatState = chatStateOf(ctx);
+  assert.equal(chatState.lastProcessedSignature, buildSignature(ctx, 3), '要按替换后的新正文重新锚定');
+
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 1, '重锚之后不再重复追踪');
+});
+
+test('请求在飞时发生无戳改写（手改/其它写回）：维持原作废逻辑', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+
+  let releaseFetch;
+  let holdNextFetch = true;
+  globalThis.fetch = async () => {
+    counter.requests += 1;
+    if (holdNextFetch) {
+      holdNextFetch = false;
+      await new Promise((resolve) => { releaseFetch = resolve; });
+    }
+    return okResponse();
+  };
+
+  ctx.chat.push({ is_user: true, name: 'User', mes: '继续' });
+  await runTracker(ctx, deps, 'poll');
+  ctx.chat.push({ is_user: false, name: 'Alice', mes: '完整正文', swipe_id: 0 });
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  const runPromise = runTracker(ctx, deps, 'poll');
+  await sleep(50);
+
+  ctx.chat[2].mes = '使用者在分析期间手改了正文';
+  releaseFetch();
+  await runPromise;
+  assert.equal(counter.requests, 1);
+  // 作废路径：该楼从未处理成功，lastProcessedSignature 不能推进到改后签名
+  const chatState = chatStateOf(ctx);
+  assert.notEqual(chatState.lastProcessedSignature, buildSignature(ctx, 3));
+
+  await runTracker(ctx, deps, 'poll'); // 下一轮重放，补上这次追踪
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '作废后照常补追');
+});
+
+test('旧存档快照没有锚点字段时维持现行为（带戳替换也照常重追）', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+
+  const chatState = chatStateOf(ctx);
+  const snap = chatState.snapshots[chatState.snapshots.length - 1];
+  delete snap.anchorVersion;
+  delete snap.tailMessageId;
+  delete snap.tailSwipeId;
+  delete snap.tailName;
+
+  await sleep(20);
+  simulateReplacement(ctx.chat[0], '被替换改写的旧楼正文（带戳）');
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 1, '没有锚点 => 不敢静默 => 维持原本的重追踪行为');
+});
+
+test('替换戳早于回执时间（历史残留）不吸收——防吃掉戳后合法改动', async () => {
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+
+  // 楼层带着很早以前的替换戳（例如插件开启前就被替换过）；之后正文被合法改动
+  if (!ctx.chat[2].extra) ctx.chat[2].extra = {};
+  ctx.chat[2].extra._acu_last_optimized_at = Date.now() - 60000;
+  await sleep(20);
+  ctx.chat[2].mes = '之后的合法改动';
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  assert.equal(counter.requests, 2, '戳早于回执 => 不能当作本轮替换吸收');
+});
+
+test('真机回归：无 id 楼层（ST/TT 实际形状）同样吸收；message_id 存在时参与比对', async () => {
+  // 本文件所有消息刻意不带 id：ST/TT 落库的消息对象本来就没有 id 字段，
+  // 曾经锚点以 id 为必要条件，导致真机上吸收永远不触发、替换后必多追一轮。
+  const { ctx, counter } = makeCtx();
+  await runTracker(ctx, deps, 'manual');
+  counter.requests = 0;
+  await trackOneReply(ctx);
+  assert.equal(counter.requests, 1);
+  for (const floor of ctx.chat) assert.equal('id' in floor, false, '测试消息必须保持无 id 的真机形状');
+
+  await replaceTail(ctx, '完整正文（变量渲染后）');
+  assert.equal(counter.requests, 1, '无 id 楼层的替换必须被吸收');
+
+  // 视图带 message_id 时：一致则吸收，不一致则拒绝（防删楼后复用同位置）
+  await replaceTail(ctx, '完整正文（变量渲染后 v2）');
+  assert.equal(counter.requests, 1);
+  ctx.chat[2].message_id = 999;
+  await sleep(20);
+  simulateReplacement(ctx.chat[2], '完整正文（变量渲染后 v3）');
+  await runTracker(ctx, deps, 'poll');
+  await sleepPastSettle();
+  await runTracker(ctx, deps, 'poll');
+  // 锚点里没有 message_id（建锚时楼层无该字段），当前楼层单方面出现 id：
+  // lenient 规则只在两边都有且不等时拒绝，单边出现不拒绝，仍吸收
+  assert.equal(counter.requests, 1, '单边 message_id 不应破坏吸收');
+});


### PR DESCRIPTION
## 背景 / 問題

在 TT 上實測（异步追踪＋MVU 額外模型解析＋資料庫正文替換全開）：同一個 AI 樓層，正文剛開始吐字時會觸發一次追蹤，MVU 更新／正文替換結束後又會再觸發一次，一個樓層被追兩次、多花額度。

根因有三（皆已對三倉源碼實證）：

1. 宿主串流按 chunk 把半成品寫進 `mes`（首格還是 `...` 佔位），chunk 間隙一旦撐過 1400ms settle 窗就被誤判為說完 → 對著殘缺正文搶發一輪。
2. MVU 門控的 4 秒寬限會在**每次正文變化時重排**，而正文替換落庫正好改變正文 → 寬限被反覆續杯（TT 實測拖出十幾秒）；且替換落地後結束事件的內容指紋對不上，門控只能回寬限慢慢等。
3. 正文替換經宿主 `setChatMessages` 原地覆寫同一樓層的 `mes`，不發任何訊息類事件；舊快照邊界簽名失配被當成新內容 → 再追一輪。另外之前一版吸收判定以消息 `id` 為必要條件，但 ST／TT 落庫的消息對象本來就沒有 `id` 欄位（已逐行核對 `saveReply` 與 TT 的 Rust→JS 整行透傳），導致真機上吸收一次都沒觸發過——本次一併修正，測試消息也全部去掉 `id` 還原真機形狀。

## 方案

1. **主生成忙碌閘門**：停止按鈕 DOM 旗標（`document.body.dataset.generating`，ST／TT 同源）∪ 未閉合的 `generation_started` 事件（含超時自愈），忙時在 settle 之前整輪跳過。不採用 `ctx.streamingProcessor`（插件持有的是載入時的一次性 `getContext()` 快照，該欄位指望不上）；也不把帶 MVU 特徵的 fetch 在飛當忙碌信號（資料庫請求體會嵌進含 `<UpdateVariable>` 的正文而被誤命中，曾把追蹤排到整條資料庫管線之後）。
2. **MVU 門控恆開啟**：设置里的相容選項刪除，等待邏輯常駐。無 MVU 時門控天然不等待（讀不到設置／全局對象／在飛信號即直接放行，無 MVU＋有／無正文替換皆已用測試鎖定）；等待全程靜默（等待提示刪除，只留 console.debug）；`ended` 監聽改在輪詢啟動時提前安裝，不再錯過事件；替換改寫只更新內容指紋、不重排寬限起點；「結束事件新鮮＋有晚於它的替換戳」直接放行，在最終正文上只追一輪。
3. **正文替換靜默吸收**（恆開、無提示）：認樓層 extra 的 `_acu_last_optimized_at`（兩家資料庫唯一寫者、隨消息存檔、跨重載有效）晚於追蹤回執 → 就地重錨快照與 `lastProcessedSignature`，多次覆寫逐次吸收；在飛請求返回時同理（沿用結果改錨，不作廢重發）。手動編輯／重擲／續寫／抽卡皆不帶此戳，照常觸發追蹤。

### 具體改動

- `scripts/tracker.js`：
  - `hostRunState`＋`isHostGenerationBusy`＋`installHostRunWatchers`（只訂 generation 三事件）；`runTracker` poll 鏈首插忙碌閘（`host_generation_in_flight`）、MVU 門之後插靜默吸收（`silent_tail_replacement`）；手動分析不受任何閘門影響。
  - MVU 門：相容開關短路刪除（`isMvuExtraAnalysisEnabled`／`shouldWaitForMvuExtraAnalysis` 簽名不變，參數改 `_settings`）；特徵計數僅作舊版 MVU（無 `isDuringExtraAnalysis` 全局）兜底；寬限不被替換重排；結束＋戳直放；等待 toast 刪除。
  - 快照錨點（`anchorVersion／tailMessageId／tailSwipeId／tailName`），身份比對對缺欄位寬容（`id` 兩邊都有才比）。
- `scripts/state.js`：錨點欄位落快照，trim 重建與 repack 透傳。
- `settings.html`／`index.js`：刪除 MVU 相容選項 UI 與讀寫。
- `tests/host_generation_busy.test.mjs`（新，6 案）、`tests/silent_text_replacement.test.mjs`（新，8 案）、`tests/mvu_gate.test.mjs`（＋5 案：特徵誤命中不連鎖、監聽早裝、寬限不重排、結束＋戳直放、開關移除後恆等待）。

## 相容性

- 舊存檔快照無錨點欄位時吸收路徑不啟用（維持原本的重追蹤行為）；舊存檔殘留的 `mvuExtraAnalysisCompat` 鍵不再被讀取，無影響。
- 非 MVU 卡、MVU 未開自動請求、`after_user` 時機、Luker 多智能體等原有放行條件原樣保留。
- TT／原版 ST 雙宿主同邏輯（皆只用 dataset 旗標＋generation 事件，不依賴各自私有 API）。

## 測試

- `node --test "tests/**/*.test.mjs"`：**384／384 通過**。
- TT 實測：目前設定下每輪回覆只追蹤一次（MVU 結束後約 2～4s 彈出追蹤，替換收尾無第二輪）。
