### PR TITLE
feat: 模型设置加思考强度选项

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ import {
   DEFAULT_SYSTEM_PROMPT,
   getApiUrlForFormat,
   normalizeApiFormat,
+  normalizeReasoningEffort,
   getCharacterWorldBookName,
   getCharacterWorldBookNameViaSTscript,
   getActiveGlobalWorldBookNames,
@@ -5717,6 +5718,7 @@ function applySettingsToForm(ctx) {
   setValue('bs-bt-api-format', normalizeApiFormat(settings.apiFormat));
   setValue('bs-bt-api-key', settings.apiKey);
   setValue('bs-bt-model', settings.model);
+  setValue('bs-bt-reasoning-effort', normalizeReasoningEffort(settings.reasoningEffort));
   updateApiEndpointPreview();
   setValue('bs-bt-formatted-output-v4', settings.formattedOutputV4 !== false);
   setValue('bs-bt-mvu-extra-analysis-compat', settings.mvuExtraAnalysisCompat !== false);
@@ -6284,6 +6286,7 @@ function readSettingsFromForm(ctx) {
   settings.apiFormat = normalizeApiFormat(getValue('bs-bt-api-format'));
   settings.apiKey = String(getValue('bs-bt-api-key')).trim();
   settings.model = String(getValue('bs-bt-model')).trim();
+  settings.reasoningEffort = normalizeReasoningEffort(getValue('bs-bt-reasoning-effort'));
   const formattedOutputToggle = document.getElementById('bs-bt-formatted-output-v4');
   if (formattedOutputToggle) settings.formattedOutputV4 = Boolean(formattedOutputToggle.checked);
   const mvuCompatToggle = document.getElementById('bs-bt-mvu-extra-analysis-compat');

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,4 +1,4 @@
-import { API_FORMATS, DEFAULT_SYSTEM_PROMPT, getApiUrlForFormat, normalizeApiFormat } from './state.js';
+import { API_FORMATS, DEFAULT_SYSTEM_PROMPT, getApiUrlForFormat, normalizeApiFormat, normalizeReasoningEffort } from './state.js';
 import {
   getHostChat,
   getHostChatCompletionSettings,
@@ -434,6 +434,7 @@ async function requestHostProxyChatCompletion(apiBase, settings, requestBody, ru
     presence_penalty: requestBody.presence_penalty,
     max_tokens: requestBody.max_tokens,
     seed: requestBody.seed,
+    reasoning_effort: requestBody.reasoning_effort,
     // 非 compat 格式交给宿主后端按 custom_api_format 翻译；response_format 不在其中
     ...(formatAware ? { custom_api_format: apiFormat } : { response_format: requestBody.response_format }),
     stream: false,
@@ -813,6 +814,20 @@ async function getResolvedPreset(settings) {
   }
 }
 
+/**
+ * 思考强度请求字段：low/medium/high/xhigh/max 原样透传；
+ * 'auto'（默认）与非法值省略该参数、由服务端自定——即插件此前的原始行为。
+ * 宿主代理路径（TT/ST）由服务端按 custom_api_format 翻译，直连 compat 原样发送；
+ * 直连原生格式里只有 Responses 有 effort 概念（reasoning.effort），Claude 的
+ * thinking 与 Gemini 的 thinkingConfig 要的是 token 数而非档位，无从忠实映射，
+ * 故不发送（宿主代理路径仍由服务端翻译，不受影响）。
+ */
+function resolveReasoningEffortField(settings) {
+  const raw = normalizeReasoningEffort(settings?.reasoningEffort);
+  if (raw === 'auto') return {};
+  return { reasoning_effort: raw };
+}
+
 function buildPresetSamplingBodyFromPreset(preset) {
   const other = preset?.other && typeof preset.other === 'object' ? preset.other : {};
   const utilityPrompts = preset?.utilityPrompts && typeof preset.utilityPrompts === 'object' ? preset.utilityPrompts : {};
@@ -1002,6 +1017,11 @@ function buildDirectPayload(fmt, requestBody) {
     };
     if (requestBody.max_tokens) payload.max_output_tokens = requestBody.max_tokens;
     if (requestBody.max_completion_tokens) payload.max_output_tokens = requestBody.max_completion_tokens;
+    // 直连 Responses 原生端点：档位原样进 reasoning.effort（服务端校验）；
+    // auto 时该字段本就不存在，直接省略
+    if (typeof requestBody.reasoning_effort === 'string' && requestBody.reasoning_effort) {
+      payload.reasoning = { effort: requestBody.reasoning_effort };
+    }
     if (requestBody.response_format?.type === 'json_object') {
       payload.text = { format: { type: 'json_object' } };
     }
@@ -1371,6 +1391,7 @@ export async function callOpenAICompatible(settings, payload, systemPrompt = DEF
     model,
     temperature: 0.2,
     ...stPresetSampling,
+    ...resolveReasoningEffortField(settings),
     messages: effectiveMessages,
     ...(useFormattedOutputV4 ? { response_format: { type: 'json_object' } } : {}),
   };
@@ -1409,6 +1430,7 @@ export async function callOpenAICompatible(settings, payload, systemPrompt = DEF
         model,
         temperature: 0.1,
         ...stPresetSampling,
+        ...resolveReasoningEffortField(settings),
         messages: [
           ...effectiveMessages,
           { role: 'assistant', content: String(content || '') },

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -127,6 +127,16 @@ export function normalizeApiFormat(value) {
   return API_FORMATS.OPENAI_COMPAT;
 }
 
+// 思考强度（reasoning_effort）档位：'auto'（默认）与非法值都省略该参数、
+// 由服务端自定——即插件此前的原始行为，存量使用者零影响
+export const REASONING_EFFORTS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max', 'auto']);
+
+export function normalizeReasoningEffort(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  if (REASONING_EFFORTS.includes(raw)) return raw;
+  return 'auto';
+}
+
 export function getApiEndpointSuffix(format) {
   switch (normalizeApiFormat(format)) {
     case API_FORMATS.OPENAI_RESPONSES: return '/responses';
@@ -166,6 +176,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   apiKey: '',
   model: 'gpt-4.1-mini',
   modelOptions: [],
+  reasoningEffort: 'auto',
   formattedOutputV4: true,
   mvuExtraAnalysisCompat: true,
   raceCatalogInPrompt: true,
@@ -883,6 +894,11 @@ export function getSettings(ctx) {
   const normalizedApiFormat = normalizeApiFormat(settings.apiFormat);
   if (settings.apiFormat !== normalizedApiFormat) {
     settings.apiFormat = normalizedApiFormat;
+    shouldSave = true;
+  }
+  const normalizedReasoningEffort = normalizeReasoningEffort(settings.reasoningEffort);
+  if (settings.reasoningEffort !== normalizedReasoningEffort) {
+    settings.reasoningEffort = normalizedReasoningEffort;
     shouldSave = true;
   }
   if (shouldSave) saveHostSettings(ctx);

--- a/settings.html
+++ b/settings.html
@@ -223,6 +223,19 @@
             </div>
 
             <div class="settings_section">
+              <label for="bs-bt-reasoning-effort">思考强度</label>
+              <select id="bs-bt-reasoning-effort" class="text_pole">
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="xhigh">XHigh</option>
+                <option value="max">Max</option>
+                <option value="auto">Auto（自动）</option>
+              </select>
+              <small>reasoning_effort，随本插件设置保存。偏小尺寸的模型拉高思考强度有助于保证输出内容正确性。默认 Auto：不传输思考强度参数，由服务端自动决定。</small>
+            </div>
+
+            <div class="settings_section">
               <label style="display:flex;align-items:center;gap:8px;">
                 <input id="bs-bt-formatted-output-v4" type="checkbox" />
                 <span>格式化输出(v4兼容)</span>

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test, { afterEach } from 'node:test';
 
 import { callOpenAICompatible, fetchModelList, isApiDeadlineError, isApiTimeoutError, resolveApiTimeoutMs, resolveOverallDeadlineMs } from '../scripts/api.js';
+import { normalizeReasoningEffort } from '../scripts/state.js';
 
 const ORIGINAL_GLOBALS = {
   fetch: globalThis.fetch,
@@ -506,4 +507,132 @@ test('gemini_interactions surfaces a failed status as a retriable error', async 
     // failed 是可重试的上游错误：可能直接抛出，也可能在重试链里撞上总时限
     (error) => /Gemini Interactions 回传失败|总时限/.test(error.message),
   );
+});
+
+test('normalizeReasoningEffort accepts 6 levels with auto fallback', () => {
+  assert.equal(normalizeReasoningEffort('high'), 'high');
+  assert.equal(normalizeReasoningEffort('XHigh'), 'xhigh');
+  assert.equal(normalizeReasoningEffort('Auto'), 'auto');
+  assert.equal(normalizeReasoningEffort(undefined), 'auto');
+  assert.equal(normalizeReasoningEffort(''), 'auto');
+  assert.equal(normalizeReasoningEffort('ultra'), 'auto');
+  // 已移除的 False 档：旧存档残留值按非法处理，回退 auto（不传参）
+  assert.equal(normalizeReasoningEffort('false'), 'auto');
+});
+
+function proxyBodyOf(calls) {
+  assert.equal(calls[0].url, '/api/backends/chat-completions/generate');
+  return JSON.parse(calls[0].options.body);
+}
+
+test('reasoning effort defaults to auto: parameter omitted on the host proxy body', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({
+      choices: [{ message: { content: JSON.stringify({ operations: [] }) } }],
+    });
+  });
+
+  await callOpenAICompatible({
+    apiUrl: 'https://example-model-host.test/v1/chat/completions',
+    apiKey: 'secret-key',
+    model: 'grok-compatible',
+  }, { recent_messages: [] }, 'Return JSON.');
+
+  // 默认 Auto = 不传 reasoning_effort——与插件引入该选项之前的请求体完全一致，
+  // 存量使用者零影响
+  assert.equal('reasoning_effort' in proxyBodyOf(calls), false);
+});
+
+test('reasoning effort auto/removed-false/invalid omit; levels pass through', async () => {
+  for (const [setting, expected, present] of [
+    ['auto', undefined, false],
+    // 已移除的 False 档：残留值回退 auto（省略），不会把 false 传给上游
+    ['false', undefined, false],
+    ['ultra', undefined, false],
+    ['high', 'high', true],
+    ['max', 'max', true],
+  ]) {
+    const calls = [];
+    installBrowserHost(async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({
+        choices: [{ message: { content: JSON.stringify({ operations: [] }) } }],
+      });
+    });
+    await callOpenAICompatible({
+      apiUrl: 'https://example-model-host.test/v1/chat/completions',
+      apiKey: 'secret-key',
+      model: 'grok-compatible',
+      reasoningEffort: setting,
+    }, { recent_messages: [] }, 'Return JSON.');
+    const body = proxyBodyOf(calls);
+    assert.equal('reasoning_effort' in body, present, `${setting} present=${present}`);
+    if (present) assert.equal(body.reasoning_effort, expected);
+  }
+});
+
+test('reasoning effort rides the format-aware host proxy for non-compat formats', async () => {
+  const calls = [];
+  globalThis.__TAURITAVERN__ = {};
+  try {
+    installBrowserHost(async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+    });
+
+    await callOpenAICompatible({
+      apiUrl: 'https://opencode.example.test/zen/go/v1',
+      apiKey: 'go-key',
+      model: 'muse-spark-1.2-contributor',
+      apiFormat: 'openai_responses',
+      reasoningEffort: 'xhigh',
+    }, { recent_messages: [] }, 'Return JSON.');
+
+    const body = proxyBodyOf(calls);
+    assert.equal(body.custom_api_format, 'openai_responses');
+    assert.equal(body.reasoning_effort, 'xhigh');
+  } finally {
+    delete globalThis.__TAURITAVERN__;
+  }
+});
+
+test('direct Responses payload carries reasoning.effort; direct Claude omits it', async () => {
+  // Responses 直连（透传代理 404 回退）：档位进 reasoning.effort
+  const responsesCalls = [];
+  installBrowserHost(async (url, options) => {
+    responsesCalls.push({ url, options });
+    if (url.startsWith('/proxy/')) {
+      return { ok: false, status: 404, async text() { return 'disabled'; } };
+    }
+    return jsonResponse(RESPONSES_RESULT);
+  });
+  await callOpenAICompatible({
+    apiUrl: 'https://opencode.example.test/zen/go/v1',
+    apiKey: 'go-key',
+    model: 'muse-spark-1.2-contributor',
+    apiFormat: 'openai_responses',
+    reasoningEffort: 'high',
+  }, { recent_messages: [] }, 'Return JSON.');
+  const responsesBody = JSON.parse(responsesCalls[responsesCalls.length - 1].options.body);
+  assert.deepEqual(responsesBody.reasoning, { effort: 'high' });
+
+  // Claude 直连原生格式没有档位概念（thinking 要 token 数）：不发送，不编造
+  const claudeCalls = [];
+  installBrowserHost(async (url, options) => {
+    claudeCalls.push({ url, options });
+    return jsonResponse({ content: [{ type: 'text', text: JSON.stringify({ operations: [] }) }] });
+  });
+  await callOpenAICompatible({
+    apiUrl: 'https://opencode.example.test/zen/go/v1',
+    apiKey: 'go-key',
+    model: 'qwen3.8-max',
+    apiFormat: 'claude_messages',
+    reasoningEffort: 'high',
+  }, { recent_messages: [] }, 'Return JSON.');
+  const claudeBody = JSON.parse(claudeCalls[0].options.body);
+  assert.equal('reasoning_effort' in claudeBody, false);
+  assert.equal('reasoning' in claudeBody, false);
+  assert.equal('thinking' in claudeBody, false);
 });


### PR DESCRIPTION
## 背景

本插件此前从不传输思考强度参数。实测 Muse Spark 1.3：在不传输（由服务端自动决定）与传输 `reasoning_effort: xhigh` 的情况下，追踪输出差别甚大；偏小尺寸的模型拉高思考强度有助于保证 JSON 结构正确性。

## 改動

模型名称下方加「思考强度」下拉：Low／Medium／High／XHigh／Max／Auto（自動）六檔，預設 **Auto**；`reasoning_effort` 原样透传（Auto 省略参数，非法值回 Auto）。

- 宿主代理路径（TT／ST）：请求体带上 `reasoning_effort`，由服务端按 `custom_api_format` 翻译。
- 直连 Responses 原生端点：档位进 `reasoning.effort`。
- 直连 Claude／Gemini 原生：无档位概念（要的是 token 数而非档位，无从忠实映射），故不发送。

### 具體改動

- `scripts/state.js`：新增 `REASONING_EFFORTS`／`normalizeReasoningEffort`；`DEFAULT_SETTINGS` 加 `reasoningEffort: 'auto'`，旧存档自动补齐并正规化。
- `scripts/api.js`：新增 `resolveReasoningEffortField`（compat 请求体与 JSON 纠错重试体）；宿主代理字段白名单加 `reasoning_effort`；直连 Responses 映射 `reasoning.effort`。
- `settings.html`／`index.js`：模型名称下方下拉 UI 与读写绑定。
- `tests/api.test.mjs`：＋5 案（归一化与非法回退、默认 Auto 省略参数、Auto/残留 false/非法值省略＋档位透传、格式感知代理、直连 Responses／Claude）。

## 相容性

- 默认 Auto 即不传参——与插件引入该选项之前的请求体完全一致，存量使用者零影响；需要时才手动调档。
- TT／原版 ST 双宿主同逻辑。

## 測試

- `node --test "tests/**/*.test.mjs"`：**371／371 通过**。
- TT 实测：Muse Spark 1.3 在 Auto 与 xhigh 下追踪输出差别明显，xhigh 侧结构稳定。
