### PR TITLE
feat: OpenCode Go 会话头（flow×卡独立，缓存最大化）

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -79,7 +79,7 @@ export function getApiBase(settings) {
   return apiBase.replace(/\/+$/, '');
 }
 
-export function getAuthHeaders(settings) {
+export function getAuthHeaders(settings, sessionId = '') {
   const headers = { 'Content-Type': 'application/json' };
   const key = settings.apiKey ? String(settings.apiKey) : '';
   const format = normalizeApiFormat(settings?.apiFormat);
@@ -95,7 +95,80 @@ export function getAuthHeaders(settings) {
   } else if (key) {
     headers.Authorization = `Bearer ${key}`;
   }
+  // OpenCode Go 凭 x-opencode-session 做路由与 prompt 缓存；只在调用方
+  // 显式算出会话 ID 时才带（见 buildOpenCodeSessionId），非 opencode 渠道恒为空
+  if (isValidOpenCodeSessionId(sessionId)) headers[OPENCODE_SESSION_HEADER] = String(sessionId);
   return headers;
+}
+
+/**
+ * OpenCode Go 会话头（https://opencode.ai/docs/go/#where-can-i-use-it）：
+ * 每个 conversation 发稳定的 x-opencode-session，供服务端做路由与 prompt 缓存。
+ * 只有 hostname 归属 opencode.ai 的 endpoint 才带，其他渠道一律不带。
+ */
+const OPENCODE_SESSION_HEADER = 'x-opencode-session';
+const OPENCODE_FLOW_NAMES = ['tracker', 'registry', 'wardrobe', 'diary', 'skill', 'breeding'];
+
+/** 汇点最后校验：非法值直接丢弃，防换行/伪造头注入。 */
+function isValidOpenCodeSessionId(sessionId) {
+  return /^bsbt-[a-z]+-[0-9a-f]{8}$/.test(String(sessionId || ''));
+}
+
+export function isOpenCodeApiBase(apiBase) {
+  const raw = String(apiBase || '').trim();
+  if (!raw) return false;
+  const candidates = raw.includes('://') ? [raw] : [`https://${raw}`];
+  for (const candidate of candidates) {
+    try {
+      const host = new URL(candidate).hostname.toLowerCase();
+      if (host === 'opencode.ai' || host.endsWith('.opencode.ai')) return true;
+    } catch {}
+  }
+  return false;
+}
+
+/** 调用方显式 flow 优先；没传时按 payload 有无 target_character 区分追踪/注册。 */
+export function resolveOpenCodeFlow(payload, explicitFlow = '') {
+  const normalized = String(explicitFlow || '').trim().toLowerCase();
+  if (OPENCODE_FLOW_NAMES.includes(normalized)) return normalized;
+  const target = payload && typeof payload === 'object' ? String(payload.target_character || '').trim() : '';
+  return target ? 'registry' : 'tracker';
+}
+
+/**
+ * 卡独立性：注册类按目标角色名区分，追踪按当前角色卡名区分。
+ * 名称只做哈希输入、不进头值——CJK 名直接放 header 会触发 fetch 的 ByteString 校验。
+ */
+function resolveOpenCodeCardKey(payload) {
+  if (!payload || typeof payload !== 'object') return '';
+  const target = String(payload.target_character || '').trim();
+  if (target) return target;
+  const current = payload.current_character && typeof payload.current_character === 'object'
+    ? String(payload.current_character.name || '').trim()
+    : '';
+  return current;
+}
+
+function hashOpenCodeSessionKey(text) {
+  let hash = 0x811c9dc5;
+  const input = String(text || '');
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * 会话 ID 形如 bsbt-tracker-9f3ac2e1：flow 与卡名双维度隔离，各自的 prompt 前缀
+ * 缓存互不冲刷；纯函数推导、无需持久化，重载页面后保持不变、缓存继续命中。
+ * 非 opencode endpoint 返回空字符串，调用方以此决定带不带头。
+ */
+export function buildOpenCodeSessionId(apiBase, payload, explicitFlow = '') {
+  if (!isOpenCodeApiBase(apiBase)) return '';
+  const flow = resolveOpenCodeFlow(payload, explicitFlow);
+  const cardKey = resolveOpenCodeCardKey(payload);
+  return `bsbt-${flow}-${hashOpenCodeSessionKey(`${flow}\n${cardKey}`)}`;
 }
 
 /**
@@ -165,7 +238,7 @@ function getHostProxyHeaders(extraHeaders = {}) {
  */
 const PLUGIN_USER_AGENT = 'BS-BioTracker (+https://github.com/Liuuuu54/st_bs_biotracker)';
 
-function buildHostProxyConfig(apiBase, settings) {
+function buildHostProxyConfig(apiBase, settings, sessionId = '') {
   const apiKey = String(settings?.apiKey || '');
   const format = normalizeApiFormat(settings?.apiFormat);
   const headerLines = [];
@@ -190,6 +263,11 @@ function buildHostProxyConfig(apiBase, settings) {
   // additional headers 最后应用，注入这里会把产品 UA 顶掉，故 TT 跳过。
   if (!hostSupportsFormatAwareProxy()) {
     headerLines.push(`User-Agent: ${PLUGIN_USER_AGENT}`);
+  }
+  // 宿主代理路径走 ST/TT 后端代发上游请求，会话头只能随 custom_include_headers
+  // 进去；非 opencode 渠道 sessionId 恒为空，不会多带
+  if (isValidOpenCodeSessionId(sessionId)) {
+    headerLines.push(`${OPENCODE_SESSION_HEADER}: ${sessionId}`);
   }
   return {
     chat_completion_source: 'custom',
@@ -438,7 +516,7 @@ async function requestHostProxyChatCompletion(apiBase, settings, requestBody, ru
     // 非 compat 格式交给宿主后端按 custom_api_format 翻译；response_format 不在其中
     ...(formatAware ? { custom_api_format: apiFormat } : { response_format: requestBody.response_format }),
     stream: false,
-    ...buildHostProxyConfig(apiBase, settings),
+    ...buildHostProxyConfig(apiBase, settings, runContext.sessionId || ''),
   };
   Object.keys(proxyBody).forEach((key) => {
     if (proxyBody[key] === undefined) delete proxyBody[key];
@@ -1052,6 +1130,8 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
     const previousAsyncFlag = globalThis.__bs_biotracker_async_request__;
     globalThis.__bs_biotracker_async_request__ = true;
     const fmt = normalizeApiFormat(settings?.apiFormat);
+    // 会话头只认 opencode endpoint，其他渠道为空、直连与代理路径都不会多带
+    const sessionId = runContext.sessionId || '';
     const upstreamUrl = getApiUrlForFormat(apiBase, fmt);
     const isCompat = fmt === API_FORMATS.OPENAI_COMPAT;
     // TT 后端按 custom_api_format 在服务端翻译；原版 ST 后端不认得这个字段
@@ -1098,7 +1178,7 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
           }
           ({ response, responseText } = await fetchText(upstreamUrl, {
             method: 'POST',
-            headers: getAuthHeaders(settings),
+            headers: getAuthHeaders(settings, sessionId),
             body: requestText,
             timeoutMs: resolveApiTimeoutMs(settings),
             externalSignal: runContext.signal || null,
@@ -1110,7 +1190,7 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
         try {
           ({ response, responseText } = await fetchText(transparentProxyUrl, {
             method: 'POST',
-            headers: getHostProxyHeaders(getAuthHeaders(settings)),
+            headers: getHostProxyHeaders(getAuthHeaders(settings, sessionId)),
             body: requestText,
             timeoutMs: resolveApiTimeoutMs(settings),
             externalSignal: runContext.signal || null,
@@ -1126,7 +1206,7 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
           url = upstreamUrl;
           ({ response, responseText } = await fetchText(upstreamUrl, {
             method: 'POST',
-            headers: getAuthHeaders(settings),
+            headers: getAuthHeaders(settings, sessionId),
             body: requestText,
             timeoutMs: resolveApiTimeoutMs(settings),
             externalSignal: runContext.signal || null,
@@ -1136,7 +1216,7 @@ async function requestChatCompletion(apiBase, settings, body, runContext = {}) {
       } else {
         ({ response, responseText } = await fetchText(upstreamUrl, {
           method: 'POST',
-          headers: getAuthHeaders(settings),
+          headers: getAuthHeaders(settings, sessionId),
           body: requestText,
           timeoutMs: resolveApiTimeoutMs(settings),
           externalSignal: runContext.signal || null,
@@ -1352,7 +1432,7 @@ async function buildPresetEnvelope(settings, baseSystemPrompt, payloadText) {
   }
 }
 
-export async function callOpenAICompatible(settings, payload, systemPrompt = DEFAULT_SYSTEM_PROMPT) {
+export async function callOpenAICompatible(settings, payload, systemPrompt = DEFAULT_SYSTEM_PROMPT, options = {}) {
   const apiBase = getApiBase(settings);
   const model = String(settings.model || '').trim();
   const stCtx = getSillyTavernContext();
@@ -1416,7 +1496,13 @@ export async function callOpenAICompatible(settings, payload, systemPrompt = DEF
       } catch {}
     }, deadlineMs);
   }
-  const runContext = { signal: overallController?.signal || null, deadlineMs };
+  const runContext = {
+    signal: overallController?.signal || null,
+    deadlineMs,
+    // opencode 会话 ID 按 flow×卡推导：同 flow 同卡多轮复用同一会话，
+    // prompt 前缀缓存不被其他 flow/卡冲掉；纠错子请求同轮沿用同一会话
+    sessionId: buildOpenCodeSessionId(apiBase, safePayload, options?.flow),
+  };
 
   try {
     return await withGlobalApiRetries(async (globalAttempt) => {

--- a/scripts/registry.js
+++ b/scripts/registry.js
@@ -486,7 +486,7 @@ async function runBreedingInference(settings, payload, options = {}) {
   const systemPrompt = options.breedingInferenceSystemPrompt || buildBreedingInferenceSystemPrompt(settings, options);
   recordBreedingInferenceRequestDebug(systemPrompt, payload);
   try {
-    const rawResult = await callOpenAICompatible(settings, payload, systemPrompt);
+    const rawResult = await callOpenAICompatible(settings, payload, systemPrompt, { flow: 'breeding' });
     const result = normalizeBreedingInferenceResult(rawResult);
     // 角色卡、最近对话中会同时出现 user 与其他人物；target_character 是 UI 的
     // 明确输入，不能把模型回传的猜测当成目标来源，否则结果会显示成 user。
@@ -665,7 +665,7 @@ export async function runRegistryWardrobeInference(ctx, options = {}) {
   payload.existing_wardrobe = chatState.characters[targetName]?.profile?.wardrobe || null;
   payload.existing_outfit = chatState.characters[targetName]?.profile?.outfit || null;
   const systemPrompt = options.wardrobePrepSystemPrompt || buildWardrobePrepSystemPrompt(settings, { ...options, wardrobePrepPrompt, wardrobePrepMainCount, wardrobePrepAccessoryCount });
-  const result = await callOpenAICompatible(settings, payload, systemPrompt);
+  const result = await callOpenAICompatible(settings, payload, systemPrompt, { flow: 'wardrobe' });
   return sanitizeWardrobePrepResult(result);
 }
 
@@ -698,7 +698,7 @@ export async function runRegistryDiaryInference(ctx, options = {}) {
       : 'payload.requested_diary_date 为空时，请依故事上下文自行填写合适的日期标题；不要使用现实系统日期。',
     '只输出 JSON：{"time":"日期标题","content":"日记正文"}。',
   ].join('\n');
-  const result = await callOpenAICompatible(settings, payload, systemPrompt);
+  const result = await callOpenAICompatible(settings, payload, systemPrompt, { flow: 'diary' });
   const time = String(result?.time || requestedDate || '').trim();
   const content = String(result?.content || '').trim();
   if (!time || !content) throw new Error('日记生成结果缺少 time 或 content');
@@ -1698,7 +1698,7 @@ export async function runRegistrySkillInference(ctx, options = {}) {
       // 图鉴为空＝本次是这个聊天的第一个角色，所有引用都只能来自本次 skillDefinitions
       emptyCatalog: payload.skill_catalog.length === 0,
     });
-  const result = await callOpenAICompatible(settings, payload, systemPrompt);
+  const result = await callOpenAICompatible(settings, payload, systemPrompt, { flow: 'skill' });
   return sanitizeRegistrySkillInferenceResult(result);
 }
 
@@ -1952,6 +1952,7 @@ export async function runRegistry(ctx, options = {}) {
       settings,
       payload,
       systemPrompt,
+      { flow: 'registry' },
     );
     if (
       options.breedingInference?.stageProfiles

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -1504,7 +1504,8 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   const rawResult = await callOpenAICompatible(
     settings,
     payload,
-    systemPrompt
+    systemPrompt,
+    { flow: 'tracker' }
   );
   recordTrackerResultDebug(rawResult);
 

--- a/tests/opencode_session.test.mjs
+++ b/tests/opencode_session.test.mjs
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import test, { afterEach } from 'node:test';
+
+import {
+  buildOpenCodeSessionId,
+  callOpenAICompatible,
+  fetchModelList,
+  getAuthHeaders,
+  isOpenCodeApiBase,
+  resolveOpenCodeFlow,
+} from '../scripts/api.js';
+
+const ORIGINAL_GLOBALS = {
+  fetch: globalThis.fetch,
+  window: globalThis.window,
+  document: globalThis.document,
+  location: globalThis.location,
+  SillyTavern: globalThis.SillyTavern,
+};
+
+afterEach(() => {
+  Object.entries(ORIGINAL_GLOBALS).forEach(([key, value]) => {
+    if (value === undefined) delete globalThis[key];
+    else globalThis[key] = value;
+  });
+  delete globalThis.__bs_biotracker_host_proxy_disabled__;
+});
+
+function installBrowserHost(fetchImpl, origin = 'http://localhost:8000') {
+  globalThis.window = {};
+  globalThis.document = { cookie: 'csrf_token=test-csrf' };
+  globalThis.location = { origin, href: `${origin}/` };
+  globalThis.SillyTavern = {
+    getContext: () => null,
+    getRequestHeaders: () => ({}),
+  };
+  globalThis.fetch = fetchImpl;
+}
+
+function jsonResponse(data, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return JSON.stringify(data);
+    },
+  };
+}
+
+const TRACKER_SETTINGS = {
+  apiUrl: 'https://opencode.ai/zen/go/v1/chat/completions',
+  apiKey: 'go-key',
+  model: 'muse-spark-1.3-contributor',
+};
+
+function trackerPayload(cardName) {
+  return { recent_messages: [], current_character: { name: cardName } };
+}
+
+test('isOpenCodeApiBase 只认 opencode.ai 归属域名', () => {
+  assert.equal(isOpenCodeApiBase('https://opencode.ai/zen/go/v1/chat/completions'), true);
+  assert.equal(isOpenCodeApiBase('https://opencode.ai/zen/go/v1'), true);
+  assert.equal(isOpenCodeApiBase('https://OPENCODE.AI/zen/go/v1'), true);
+  assert.equal(isOpenCodeApiBase('https://go.opencode.ai/v1'), true);
+  assert.equal(isOpenCodeApiBase('opencode.ai/zen/go/v1'), true);
+  assert.equal(isOpenCodeApiBase('https://example-model-host.test/v1'), false);
+  assert.equal(isOpenCodeApiBase('https://opencode.ai.evil.test/v1'), false);
+  assert.equal(isOpenCodeApiBase('https://notopencode.ai/v1'), false);
+  assert.equal(isOpenCodeApiBase(''), false);
+  assert.equal(isOpenCodeApiBase('/v1'), false);
+});
+
+test('buildOpenCodeSessionId 非 opencode 渠道恒为空', () => {
+  assert.equal(buildOpenCodeSessionId('https://example-model-host.test/v1', trackerPayload('A'), 'tracker'), '');
+  assert.equal(buildOpenCodeSessionId('', trackerPayload('A'), 'tracker'), '');
+});
+
+test('buildOpenCodeSessionId 同 flow 同卡稳定、跨 flow 跨卡隔离', () => {
+  const first = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲'), 'tracker');
+  const second = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲'), 'tracker');
+  assert.match(first, /^bsbt-tracker-[0-9a-f]{8}$/);
+  assert.equal(second, first);
+  const otherCard = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('Bob'), 'tracker');
+  assert.match(otherCard, /^bsbt-tracker-[0-9a-f]{8}$/);
+  assert.notEqual(otherCard, first);
+  const otherFlow = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲'), 'diary');
+  assert.match(otherFlow, /^bsbt-diary-[0-9a-f]{8}$/);
+  assert.notEqual(otherFlow, first);
+});
+
+test('resolveOpenCodeFlow 没传 flow 时按 target_character 回退', () => {
+  assert.equal(resolveOpenCodeFlow({ recent_messages: [] }, ''), 'tracker');
+  assert.equal(resolveOpenCodeFlow({ target_character: 'A' }, ''), 'registry');
+  assert.equal(resolveOpenCodeFlow({ target_character: 'A' }, 'nope'), 'registry');
+  assert.equal(resolveOpenCodeFlow({ target_character: 'A' }, 'skill'), 'skill');
+  const fallback = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, { target_character: 'A' });
+  assert.match(fallback, /^bsbt-registry-[0-9a-f]{8}$/);
+});
+
+test('getAuthHeaders 只在给了会话 ID 时带会话头', () => {
+  assert.equal(getAuthHeaders({ apiKey: 'k' })['x-opencode-session'], undefined);
+  assert.equal(getAuthHeaders({ apiKey: 'k' }, 'bsbt-tracker-1234abcd')['x-opencode-session'], 'bsbt-tracker-1234abcd');
+  // 非法值直接丢弃：换行注入与伪造格式到不了发包头
+  assert.equal(getAuthHeaders({ apiKey: 'k' }, 'bsbt-tracker-1234abcd\nX-Injected: 1')['x-opencode-session'], undefined);
+  assert.equal(getAuthHeaders({ apiKey: 'k' }, 'not-a-session')['x-opencode-session'], undefined);
+});
+
+test('宿主代理路径：opencode 带会话头、其他渠道不带', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+  });
+
+  await callOpenAICompatible(TRACKER_SETTINGS, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+  await callOpenAICompatible(
+    { apiUrl: 'https://example-model-host.test/v1/chat/completions', apiKey: 'k', model: 'm' },
+    trackerPayload('愛麗絲'),
+    'Return JSON.',
+    { flow: 'tracker' },
+  );
+
+  assert.equal(calls.length, 2);
+  const sessionLines = (index) => JSON.parse(calls[index].options.body)
+    .custom_include_headers.split('\n').filter((line) => line.startsWith('x-opencode-session: '));
+  assert.equal(sessionLines(0).length, 1);
+  assert.match(sessionLines(0)[0], /^x-opencode-session: bsbt-tracker-[0-9a-f]{8}$/);
+  assert.deepEqual(sessionLines(1), []);
+});
+
+test('宿主代理路径：同 flow 同卡多轮复用同一会话 ID', async () => {
+  const seen = [];
+  installBrowserHost(async (url, options) => {
+    seen.push(JSON.parse(options.body).custom_include_headers);
+    return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+  });
+
+  await callOpenAICompatible(TRACKER_SETTINGS, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+  await callOpenAICompatible(TRACKER_SETTINGS, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0], seen[1]);
+  assert.match(seen[0], /x-opencode-session: bsbt-tracker-[0-9a-f]{8}/);
+});
+
+test('直连路径：opencode 带会话头、其他渠道不带', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+  }, 'https://opencode.ai');
+
+  await callOpenAICompatible(TRACKER_SETTINGS, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://opencode.ai/zen/go/v1/chat/completions');
+  assert.match(calls[0].options.headers['x-opencode-session'], /^bsbt-tracker-[0-9a-f]{8}$/);
+
+  const directCalls = [];
+  installBrowserHost(async (url, options) => {
+    directCalls.push({ url, options });
+    return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+  }, 'https://my-proxy.test');
+  await callOpenAICompatible(
+    { apiUrl: 'https://my-proxy.test/v1', apiKey: 'k', model: 'm' },
+    trackerPayload('愛麗絲'),
+    'Return JSON.',
+    { flow: 'tracker' },
+  );
+  assert.equal(directCalls.length, 1);
+  assert.equal(directCalls[0].options.headers['x-opencode-session'], undefined);
+});
+
+test('模型列表探测不带会话头（无 prompt、无缓存意义）', async () => {
+  const calls = [];
+  installBrowserHost(async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({ data: [{ id: 'muse-spark-1.3-contributor' }] });
+  });
+
+  const models = await fetchModelList({ apiUrl: 'https://opencode.ai/zen/go/v1', apiKey: 'go-key' });
+  assert.deepEqual(models, ['muse-spark-1.3-contributor']);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, '/api/backends/chat-completions/status');
+  const includeHeaders = JSON.parse(calls[0].options.body).custom_include_headers;
+  assert.equal(includeHeaders.includes('x-opencode-session'), false);
+});

--- a/tests/opencode_session.test.mjs
+++ b/tests/opencode_session.test.mjs
@@ -128,6 +128,26 @@ test('宿主代理路径：opencode 带会话头、其他渠道不带', async ()
   assert.deepEqual(sessionLines(1), []);
 });
 
+test('中途切换预设到非 opencode：头自动消失，切回即恢复同一 ID', async () => {
+  const seen = [];
+  installBrowserHost(async (url, options) => {
+    seen.push(JSON.parse(options.body).custom_include_headers);
+    return jsonResponse({ choices: [{ message: { content: JSON.stringify({ operations: [] }) } }] });
+  });
+  const otherPreset = { apiUrl: 'https://example-model-host.test/v1/chat/completions', apiKey: 'k', model: 'm' };
+
+  await callOpenAICompatible(TRACKER_SETTINGS, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+  await callOpenAICompatible(otherPreset, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+  await callOpenAICompatible(TRACKER_SETTINGS, trackerPayload('愛麗絲'), 'Return JSON.', { flow: 'tracker' });
+
+  assert.equal(seen.length, 3);
+  const sessionOf = (headers) => headers.split('\n').find((line) => line.startsWith('x-opencode-session: '));
+  assert.match(sessionOf(seen[0]), /^x-opencode-session: bsbt-tracker-[0-9a-f]{8}$/);
+  assert.equal(sessionOf(seen[1]), undefined);
+  // 切回 opencode 是同一 ID：缓存继续命中，无粘性状态残留
+  assert.equal(sessionOf(seen[2]), sessionOf(seen[0]));
+});
+
 test('宿主代理路径：同 flow 同卡多轮复用同一会话 ID', async () => {
   const seen = [];
   installBrowserHost(async (url, options) => {


### PR DESCRIPTION
## 背景

OpenCode Go 要求客戶端為每個 conversation 發送穩定的 `x-opencode-session`（參見 [Where can I use it?](https://opencode.ai/docs/go/#where-can-i-use-it)）。這不是可選的緩存優化——實測缺頭的請求會被服務端直接拒絕：`status 400 · non-retryable`，`Request is missing x-opencode-session and cannot be routed efficiently`。本插件此前完全沒有這個頭：直連走瀏覽器 fetch、代理走 ST/TT 後端，兩條路都不帶；用 Go 當渠道時追蹤請求直接報錯，功能不可用。

## 方案

會話 ID 按「功能流 × 角色卡」二維隔離、純函數推導，形如 `bsbt-tracker-9f3ac2e1`：

- 功能流：追蹤 / 註冊 / 備裝 / 日記 / 技能 / 繁育推演共 6 個 flow，各自 prompt 前綴完全不同，必須分屬不同會話，否則互相沖刷緩存；
- 角色卡：註冊類按 `target_character` 區分，追蹤按當前角色卡名區分；
- 卡名只做 FNV-1a 哈希輸入、不進頭值（CJK 名直接放 header 會觸發 fetch 的 ByteString 校驗）；
- 純函數、無需持久化，重載頁面後 ID 不變，緩存繼續命中；
- 只有 hostname 歸屬 `opencode.ai` 的 endpoint 才帶頭，其他渠道一律不帶；
- `/models` 探測無 prompt、無緩存意義，刻意不帶。

## 具體改動

- `scripts/api.js`：新增 `isOpenCodeApiBase`（hostname 精確比對 + `.opencode.ai` 後綴，大小寫/無 scheme/端口均處理）、`resolveOpenCodeFlow`（調用方顯式 flow 優先，缺省按有無 `target_character` 回退為 registry/tracker）、`buildOpenCodeSessionId`；`getAuthHeaders` 與 `buildHostProxyConfig` 新增可選 `sessionId` 參數，匯點以正則 `^bsbt-[a-z]+-[0-9a-f]{8}$` 校验、非法值直接丟棄（防換行注入偽造頭）；`callOpenAICompatible` 新增第 4 參數 `options.flow`，會話 ID 隨 `runContext` 走遍宿主代理 / 透明代理 / 直連 / 代理失敗回退直連四條路徑，重試與 JSON 糾錯子請求同輪沿用同一 ID。
- `scripts/tracker.js`、`scripts/registry.js`：6 個調用點傳入 `flow`（tracker/registry/wardrobe/diary/skill/breeding）。
- `tests/opencode_session.test.mjs`：新增 10 個用例（域名判定、穩定性與隔離、回退邏輯、代理/直連帶頭、非 opencode 不帶、中途切預設頭自動消失且切回恢復同一 ID、模型列表不帶、非法 ID 丟棄）。

## 相容性

- 非 opencode 渠道行為零變化：`buildOpenCodeSessionId` 恆返空字串，兩匯點不加頭（既有 `tests/api.test.mjs` 精確斷言 `custom_include_headers` 的舊用例全部不受影響）。
- 中途把預設切到非 opencode 渠道：每次請求都按當前 `apiUrl` 現場推導，無粘性狀態，切過去即不帶頭、切回來即恢復同一 ID（新用例鎖定）。
- 直連是瀏覽器 fetch，`User-Agent` 為 forbidden header 無法自設——代理路徑已有 `PLUGIN_USER_AGENT`（ST）/ TT 自有 UA，本改動不碰 UA。
- 自託管 Go 若網關未放行該自定義頭，直連跨域預檢可能失敗；失敗走既有 `direct-after-proxy-*` 回退/報錯路徑，不引入新靜默行為。

## 測試

- 新增 `tests/opencode_session.test.mjs` 10/10 綠；
- 全套 `node --test --test-timeout=30000 "tests/**/*.test.mjs"`：**405/405 綠**；
- 另派三路子代理做唯讀審查（安全注入 / 傳輸路徑覆蓋 / 緩存語義），審查抓出的兩處回歸（日記 `time` 變量、技能 `return` 誤刪）已修復並重新全綠，匯點正則加固亦按建議落實。
