### PR TITLE
feat: 会话 ID 再按聊天隔离（同卡多开不互冲）

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -149,6 +149,15 @@ function resolveOpenCodeCardKey(payload) {
   return current;
 }
 
+/**
+ * 聊天粒度：同卡不同聊天分属不同会话，否则两个聊天的不同前缀交替冲刷缓存。
+ * 缺 chat_id 时回退到卡级（旧行为），只损命中率、不影响正确性。
+ */
+function resolveOpenCodeChatKey(payload) {
+  if (!payload || typeof payload !== 'object') return '';
+  return String(payload.chat_id || '').trim();
+}
+
 function hashOpenCodeSessionKey(text) {
   let hash = 0x811c9dc5;
   const input = String(text || '');
@@ -160,7 +169,7 @@ function hashOpenCodeSessionKey(text) {
 }
 
 /**
- * 会话 ID 形如 bsbt-tracker-9f3ac2e1：flow 与卡名双维度隔离，各自的 prompt 前缀
+ * 会话 ID 形如 bsbt-tracker-9f3ac2e1：flow×卡×聊天三维隔离，各自的 prompt 前缀
  * 缓存互不冲刷；纯函数推导、无需持久化，重载页面后保持不变、缓存继续命中。
  * 非 opencode endpoint 返回空字符串，调用方以此决定带不带头。
  */
@@ -168,7 +177,9 @@ export function buildOpenCodeSessionId(apiBase, payload, explicitFlow = '') {
   if (!isOpenCodeApiBase(apiBase)) return '';
   const flow = resolveOpenCodeFlow(payload, explicitFlow);
   const cardKey = resolveOpenCodeCardKey(payload);
-  return `bsbt-${flow}-${hashOpenCodeSessionKey(`${flow}\n${cardKey}`)}`;
+  const chatKey = resolveOpenCodeChatKey(payload);
+  // 数组序列化做哈希输入：分隔符无歧义，单行假设不成立时也不会串味
+  return `bsbt-${flow}-${hashOpenCodeSessionKey(JSON.stringify([flow, cardKey, chatKey]))}`;
 }
 
 /**
@@ -1499,8 +1510,8 @@ export async function callOpenAICompatible(settings, payload, systemPrompt = DEF
   const runContext = {
     signal: overallController?.signal || null,
     deadlineMs,
-    // opencode 会话 ID 按 flow×卡推导：同 flow 同卡多轮复用同一会话，
-    // prompt 前缀缓存不被其他 flow/卡冲掉；纠错子请求同轮沿用同一会话
+    // opencode 会话 ID 按 flow×卡×聊天推导：同 flow 同卡同聊天多轮复用同一会话，
+    // prompt 前缀缓存不被其他 flow/卡/聊天冲掉；纠错子请求同轮沿用同一会话
     sessionId: buildOpenCodeSessionId(apiBase, safePayload, options?.flow),
   };
 

--- a/tests/opencode_session.test.mjs
+++ b/tests/opencode_session.test.mjs
@@ -53,8 +53,8 @@ const TRACKER_SETTINGS = {
   model: 'muse-spark-1.3-contributor',
 };
 
-function trackerPayload(cardName) {
-  return { recent_messages: [], current_character: { name: cardName } };
+function trackerPayload(cardName, chatId = 'chat-1') {
+  return { recent_messages: [], chat_id: chatId, current_character: { name: cardName } };
 }
 
 test('isOpenCodeApiBase 只认 opencode.ai 归属域名', () => {
@@ -86,6 +86,19 @@ test('buildOpenCodeSessionId 同 flow 同卡稳定、跨 flow 跨卡隔离', () 
   const otherFlow = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲'), 'diary');
   assert.match(otherFlow, /^bsbt-diary-[0-9a-f]{8}$/);
   assert.notEqual(otherFlow, first);
+});
+
+test('buildOpenCodeSessionId 同卡不同聊天隔离、无 chat_id 回退卡级', () => {
+  const chat1 = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲', 'chat-1'), 'tracker');
+  const chat1Again = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲', 'chat-1'), 'tracker');
+  assert.equal(chat1Again, chat1);
+  const chat2 = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, trackerPayload('愛麗絲', 'chat-2'), 'tracker');
+  assert.match(chat2, /^bsbt-tracker-[0-9a-f]{8}$/);
+  assert.notEqual(chat2, chat1);
+  const noChat = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, { recent_messages: [], current_character: { name: '愛麗絲' } }, 'tracker');
+  const noChatAgain = buildOpenCodeSessionId(TRACKER_SETTINGS.apiUrl, { recent_messages: [], current_character: { name: '愛麗絲' } }, 'tracker');
+  assert.match(noChat, /^bsbt-tracker-[0-9a-f]{8}$/);
+  assert.equal(noChatAgain, noChat);
 });
 
 test('resolveOpenCodeFlow 没传 flow 时按 target_character 回退', () => {


### PR DESCRIPTION
## 背景

#9 合入後，會話 ID 是 `flow × 卡` 兩維（`bsbt-tracker-9f3ac2e1`）。同一角色開兩個聊天時，兩邊前綴不同的請求共用一個會話，在服務端交替沖刷緩存——卡級共享的代價落在多開同卡的常用場景上，應該再按聊天隔離。

## 方案

哈希輸入從 `flow + 卡名` 加一維為 `flow + 卡名 + chat_id`（`payload.chat_id` 即宿主聊天穩定 ID，追蹤/註冊兩類 payload 恆帶）。同卡不同聊天各自獨立會話；取不到 `chat_id` 的非標 payload 回退到卡級，只損命中率、不影響正確性。仍是純函數推導、無持久化；老 `flow+卡` ID 自然失配，僅全量一次 miss 重建。

## 具體改動

- `scripts/api.js`：新增 `resolveOpenCodeChatKey`；`buildOpenCodeSessionId` 哈希輸入改為 `JSON.stringify([flow, cardKey, chatKey])`（數組序列化，分隔符無歧義）。
- `tests/opencode_session.test.mjs`：`trackerPayload` 默認帶 `chat_id`；新增用例鎖定同卡異 chat 相異、無 `chat_id` 回退卡級且穩定。

## 相容性

- 非 opencode 渠道仍恆不帶頭；TT 未就緒時首次請求可能拿到 fallback chat key、就緒後漂移一次（僅多一次 miss，自愈），新建未保存的多空聊天共用 `char:solo` 會話（僅命中率損失）。
- `User-Agent`、傳輸路徑、重試語義均未動。

## 測試

- `tests/opencode_session.test.mjs` 11/11 綠；
- 全套 `node --test --test-timeout=30000 "tests/**/*.test.mjs"`：**408/408 綠**；
- 子代理唯讀審查（payload 全覆蓋 / 雙宿主 chat_id 穩定性 / 分隔符歧義 / 舊緩存平滑 / 用例語義）：無正確性問題，`JSON.stringify` 串接即按其建議落實。
