### PR TITLE
fix: MVU 門控改以「全局在場」為準，不再只憑殘留設定空等

### DIFF
--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -1574,6 +1574,29 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   return { discarded: false, triggered: true };
 }
 
+/**
+ * 轮询跳过原因显形：下面几条自动独有的早退原本全程静默，面板停在旧结果上，
+ * 使用者分不清「已追完」「正在等」还是「被某道门卡死」（自动不可用、手动可用
+ * 时只能瞎猜）。只在「同聊天＋同原因」变化时写一次，避免每 1.8 秒刷一次
+ * 持久化与面板；追踪一旦真正跑起来，结果会照常覆盖这里。
+ */
+const lastPollSkipReport = { chatKey: '', reason: '' };
+export const __pollSkipReportForTest = lastPollSkipReport;
+
+export function recordPollSkip(ctx, chatState, deps, reason, message) {
+  const chatKey = String(getChatKey(ctx) || '');
+  if (lastPollSkipReport.chatKey === chatKey && lastPollSkipReport.reason === reason) {
+    return { skipped: true, reason };
+  }
+  lastPollSkipReport.chatKey = chatKey;
+  lastPollSkipReport.reason = reason;
+  chatState.lastRawResult = { message, tool_calls: [] };
+  chatState.lastOperationLogs = [];
+  saveSettings(ctx);
+  deps.renderStatusPanel(ctx);
+  return { skipped: true, reason };
+}
+
 export async function runTracker(ctx, deps, reason = 'manual') {
   const settings = getSettings(ctx);
   await hydrateChatStateFromHost(ctx, settings);
@@ -1632,7 +1655,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
   }
   if (reason === 'poll' && isHostGenerationBusy(ctx)) {
     // 主连接没说完话就绝不追踪：从根上消灭「开始吐字时抢发一轮」
-    return { skipped: true, reason: 'host_generation_in_flight' };
+    return recordPollSkip(ctx, chatState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
   }
   if (reason === 'poll') {
     const agentBarrier = await getHostAgentRunBarrier(ctx, lastMessage);
@@ -1658,20 +1681,26 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     }
   }
   if (reason === 'poll' && !isAfterAiMessageSettled(ctx, settings, chatState)) {
-    return { skipped: true, reason: 'message_not_settled' };
+    return recordPollSkip(ctx, chatState, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
   }
   if (reason === 'poll' && !hasPendingChatHistory(ctx, chatState)) {
-    return { skipped: true, reason: 'no_pending_history' };
+    return recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
   }
   if (reason === 'poll' && shouldWaitForMvuExtraAnalysis(ctx, settings)) {
-    return { skipped: true, reason: 'waiting_mvu_extra_analysis' };
+    return recordPollSkip(ctx, chatState, deps, 'waiting_mvu_extra_analysis', '等待 MVU 额外解析结束后再追踪。');
   }
   if (reason === 'poll' && tryAdoptSilentTailReplacement(ctx, settings, chatState)) {
     // 正文替换的无痕改写：静默重锚，不发请求也不弹任何提示
     return { skipped: true, reason: 'silent_tail_replacement' };
   }
   if (reason === 'poll' && isFailedAutoRetryBlocked(ctx, chatState)) {
-    return { skipped: true, reason: 'failed_message_blocked' };
+    return recordPollSkip(
+      ctx,
+      chatState,
+      deps,
+      'failed_message_blocked',
+      '上次自动追踪失败，对话无变化时暂停自动重试；可手动分析或等待新消息。',
+    );
   }
   const runToken = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   globalThis[RUN_RUNTIME_KEY] = runToken;
@@ -1736,7 +1765,15 @@ export async function runTracker(ctx, deps, reason = 'manual') {
 
 export async function poll(ctx, deps) {
   const settings = getSettings(ctx);
-  if (!settings.enabled) return;
+  if (!settings.enabled) {
+    return recordPollSkip(
+      ctx,
+      getChatState(ctx, settings),
+      deps,
+      'disabled',
+      '自动追踪未启用（在设置中开启后生效）。',
+    );
+  }
   await runTracker(ctx, deps, 'poll');
 }
 

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -288,6 +288,14 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
   // fetch 钩子必须在首次评估前就装好：否则正文后第一时间启动的 MVU 请求会被漏观测
   installMvuFetchHook();
 
+  // MVU 只在「优先实例」上把 Mvu 挂到 window.parent（见其 store 的 should_enable），
+  // 所以全局不在场＝本轮没有激活的 MVU 实例＝不会有人做额外模型解析。
+  const mvu = getMvuApi();
+  const mvuPresent = mvu !== null;
+  // 不在场就抹掉「见过 MVU 信号」的记忆：该标记是页面级粘性、生产路径上无人清除，
+  // 停用 MVU 或换到没有 MVU 的卡之后它仍为真，会让每一轮都白等一次宽限期。
+  if (!mvuPresent) mvuGateState.everSawMvuSignal = false;
+
   const mvuSettings = getMvuSettings(ctx);
   const method = mvuSettings?.更新方式;
   // 能读到设置且明确是随AI输出 → 不需要等待
@@ -297,12 +305,16 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
     const autoRequest = mvuSettings?.额外模型解析配置?.启用自动请求 ?? mvuSettings?.自动触发额外模型解析;
     if (autoRequest === false) return false;
   }
-  const mvu = getMvuApi();
-  const mvuCapable = mvu && typeof mvu.isDuringExtraAnalysis === 'function';
+  // 设置是会话无关的持久态，会残留：mvu_settings 存在 SillyTavern.extensionSettings
+  // （全局、跨卡跨聊天共享、MVU 落盘后无人清理），停用 MVU 或换到没有 MVU 的卡之后
+  // 它依然在。只凭设置就认定「本环境有 MVU」，会把这类用户当成 MVU 用户——每轮白等
+  // 宽限期，并让下面的 fetch 兜底信号生效（最长 120 秒）。故设置须与「全局在场」同时
+  // 成立才算证据。
+  const mvuCapable = Boolean(mvu && typeof mvu.isDuringExtraAnalysis === 'function');
   // 三种信号源全部不可用（fetch 被禁用、无 Mvu、设置读不到）→ 无从判断
   if (!mvuGateState.fetchHooked && !mvuCapable && method !== '额外模型解析') return false;
   if (mvuCapable) mvuGateState.everSawMvuSignal = true;
-  if (method === '额外模型解析') mvuGateState.everSawMvuSignal = true;
+  if (mvuPresent && method === '额外模型解析') mvuGateState.everSawMvuSignal = true;
 
   installMvuGateListener(ctx);
   const roundKey = getMvuRoundKey(ctx);
@@ -328,12 +340,12 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
 
   // 信号 1：MVU 全局 API 报告正在解析
   const during = mvuCapable && mvu.isDuringExtraAnalysis() === true;
-  // 信号 2：正文之后仍有非本插件的生成请求在飞行——仅作旧版 MVU（没有
-  // isDuringExtraAnalysis 全局）的兜底。请求特征会被误命中：数据库正文替换/
-  // 填表的请求体嵌着含 <UpdateVariable>、json_patch 字样的正文与提示词，全局
-  // 标志可得时不再采信它，否则兼容门控会串行等完数据库一整条后处理管线
-  // （TT 实测一分钟以上的延迟）。
-  const generateActive = !mvuCapable && mvuGateState.generateInFlight > 0;
+  // 信号 2：正文之后仍有非本插件的生成请求在飞行——仅作旧版 MVU（全局在场但它
+  // 没有 isDuringExtraAnalysis 方法）的兜底。请求特征会被误命中：数据库正文替换/
+  // 填表的请求体嵌着含 <UpdateVariable>、json_patch 字样的正文与提示词。
+  // 两个前提缺一不可：只有全局在场才说明真有 MVU 可能在做解析（否则没人会解析，
+  // 等下去纯属空转），且只有带不了权威标志的旧版才需要退而采信请求特征。
+  const generateActive = mvuPresent && !mvuCapable && mvuGateState.generateInFlight > 0;
   // 生成请求只作为本轮「在飞」等待信号，不参与 everSawMvuSignal——
   // 否则普通 ST 主流请求也会让设备被标记为「见过 MVU 信号」，导致每轮白等宽限
   if (during) mvuGateState.everSawMvuSignal = true;

--- a/tests/mvu_gate.test.mjs
+++ b/tests/mvu_gate.test.mjs
@@ -264,17 +264,74 @@ test('额外模型解析但自动请求关闭 → 门控直接放行', () => {
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), false);
 });
 
-test('TT 场景：读不到设置、无 Mvu，但确认是 MVU 额外解析请求在飞行 → 等待', () => {
+test('完全没有 Mvu 全局时，特征请求在飞也不等待（第三方插件误命中不再空等）', () => {
   resetGate();
   const ctx = makeCtx(); // 无 mvu_settings、无 Mvu 全局
   const settings = makeSettings();
   // 首次评估：未看到信号
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
-  // MVU 的额外解析请求开始飞行（fetch 钩子观测到）
+  // 某个第三方插件（数据库正文替换/填表转发聊天正文）的请求命中 MVU 特征、在飞行：
+  // 没有激活的 MVU 实例就不会有人解析变量（MVU 只在优先实例上挂 window.parent.Mvu），
+  // 此时等待纯属空转——这正是无 MVU 用户被拖住的历史路径
   __mvuGateStateForTest.generateInFlight = 1;
   __mvuGateStateForTest.lastGenerateStartedAt = Date.now();
   __mvuGateStateForTest.sawGenerateThisRound = true;
-  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('回归：停用 MVU 后 mvu_settings 残留、Mvu 全局不在场 → 不等待', () => {
+  resetGate();
+  // MVU 把设置写在 SillyTavern.extensionSettings.mvu_settings（全局、跨卡共享、
+  // 无人清理），所以换到没有 MVU 的卡或停用 MVU 后设置仍在；而 Mvu 全局会随
+  // 优先实例缺席而不在场。只凭设置就等待，会让这类用户每轮白等宽限期。
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  const settings = makeSettings();
+  assert.equal(globalThis.Mvu, undefined, '前提：没有 Mvu 全局');
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false, '设置残留不应单独构成等待理由');
+  assert.equal(
+    __mvuGateStateForTest.everSawMvuSignal,
+    false,
+    '残留设置不得把设备标记为「见过 MVU 信号」（否则之后每轮都白等宽限）',
+  );
+  // 即便有特征请求在飞也照样放行：没有 MVU 实例，没人会解析
+  __mvuGateStateForTest.generateInFlight = 1;
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('旧版 MVU：全局在场但没有 isDuringExtraAnalysis → 仍按请求特征兜底等待', () => {
+  resetGate();
+  // 旧版 MVU 只暴露 Mvu 全局、没有权威的解析状态方法
+  globalThis.Mvu = { getMvuData: () => ({}) };
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  const settings = makeSettings();
+  __mvuGateStateForTest.generateInFlight = 1;
+  __mvuGateStateForTest.lastGenerateStartedAt = Date.now();
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true, '旧版兜底路径必须保留');
+  __mvuGateStateForTest.generateInFlight = 0;
+  __mvuGateStateForTest.pendingSince = Date.now() - 5000;
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('在场判定要认 window.parent.Mvu（MVU 跑在酒馆助手 iframe 时挂在父窗口）', () => {
+  resetGate();
+  // MVU 作为酒馆助手脚本运行在 iframe，把全局挂到 window.parent；本插件若也在
+  // iframe 之外的上下文里取，就必须认这条分支——门控现在以「全局在场」为门槛
+  globalThis.parent = { Mvu: { isDuringExtraAnalysis: () => true } };
+  try {
+    const ctx = makeCtx();
+    assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), true, 'parent 上的 Mvu 应被认作在场');
+  } finally {
+    delete globalThis.parent;
+  }
+});
+
+test('Mvu 全局不是对象时不算在场（不放行出兜底等待）', () => {
+  resetGate();
+  // getMvuApi 只认对象；万一 MVU 暴露成函数或原始值，不能当作「有 MVU」
+  globalThis.Mvu = () => {};
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), false);
+  assert.equal(__mvuGateStateForTest.everSawMvuSignal, false);
 });
 
 test('fetch 钩子只认 MVU 特征请求：普通 ST 主线生成不触发（误报回归）', () => {
@@ -378,6 +435,8 @@ test('端到端：MVU 额外解析请求经过真实 fetch 钩子触发等待', 
 
 test('生成请求结束后放行', () => {
   resetGate();
+  // 走旧版兜底路径：全局在场（才有解析可能）但没有权威状态方法
+  globalThis.Mvu = { getMvuData: () => ({}) };
   const ctx = makeCtx();
   const settings = makeSettings();
   // 请求在飞行 → 等待
@@ -386,11 +445,14 @@ test('生成请求结束后放行', () => {
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
   // 请求完成 → 放行（MVU 变量已更新）
   __mvuGateStateForTest.generateInFlight = 0;
+  __mvuGateStateForTest.pendingSince = Date.now() - 5000;
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
 });
 
 test('见过 MVU 信号后，无信号轮次走宽限期等待', () => {
   resetGate();
+  // MVU 在场（没有权威状态方法，走旧版兜底那条）
+  globalThis.Mvu = { getMvuData: () => ({}) };
   const ctx = makeCtx();
   const settings = makeSettings();
   // 之前某轮见过生成请求（everSaw 为 true）
@@ -400,6 +462,17 @@ test('见过 MVU 信号后，无信号轮次走宽限期等待', () => {
   // 超过宽限期仍未出现信号 → 放行
   __mvuGateStateForTest.pendingSince = Date.now() - 5000;
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('MVU 不在场时粘性标记被清除：停用/换卡后不再每轮白等宽限', () => {
+  resetGate();
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  const settings = makeSettings();
+  // 模拟本页早先见过 MVU 信号、之后 MVU 消失（停用脚本或换到无 MVU 的卡）
+  __mvuGateStateForTest.everSawMvuSignal = true;
+  assert.equal(globalThis.Mvu, undefined, '前提：此刻没有 Mvu 全局');
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+  assert.equal(__mvuGateStateForTest.everSawMvuSignal, false, '不在场时应抹掉记忆，下一轮才不会再白等');
 });
 
 test('mainflow 快照绑定当前聊天：跨聊天/无绑定一律拒绝', () => {

--- a/tests/poll_skip_report.test.mjs
+++ b/tests/poll_skip_report.test.mjs
@@ -1,0 +1,140 @@
+// 轮询跳过原因显形：自动独有的静默早退必须在面板留下原因，
+// 否则“自动不可用、手动可用”时无从定位。只在原因变化时写一次。
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as state from '../scripts/state.js';
+import {
+  __pollSkipReportForTest,
+  poll,
+  recordPollSkip,
+  runTracker,
+  installHostRunWatchers,
+  __hostRunStateForTest,
+  __mvuGateStateForTest,
+} from '../scripts/tracker.js';
+
+function makeFakeEventBus() {
+  const handlers = new Map();
+  return {
+    on(name, handler) {
+      if (!handlers.has(name)) handlers.set(name, []);
+      handlers.get(name).push(handler);
+    },
+    emit(name, ...args) {
+      (handlers.get(name) || []).forEach((handler) => handler(...args));
+    },
+  };
+}
+
+function resetGates(ctx) {
+  const run = __hostRunStateForTest;
+  run.listenersInstalled = false;
+  run.generationDepth = 0;
+  run.generationBusySince = 0;
+  run.mutSeq = 0;
+  run.ctxRef = null;
+  const gate = __mvuGateStateForTest;
+  gate.lastEndedKey = '';
+  gate.lastEndedContentKey = '';
+  gate.lastEndedAt = 0;
+  gate.pendingKey = '';
+  gate.pendingContentKey = '';
+  gate.pendingSince = 0;
+  gate.generateInFlight = 0;
+  gate.lastGenerateStartedAt = 0;
+  gate.sawGenerateThisRound = false;
+  gate.everSawMvuSignal = false;
+  __pollSkipReportForTest.chatKey = '';
+  __pollSkipReportForTest.reason = '';
+  delete globalThis.Mvu;
+  delete globalThis.document;
+  if (ctx?.eventSource) installHostRunWatchers(ctx);
+}
+
+function makeCtx(chatId = 'skip-report-chat') {
+  const ctx = {
+    chatId,
+    chat: [{ is_user: false, name: 'Alice', mes: 'previous reply', swipe_id: 0 }],
+    extensionSettings: {},
+    saveSettingsDebounced() {},
+    eventSource: makeFakeEventBus(),
+    eventTypes: {
+      GENERATION_STARTED: 'generation_started',
+      GENERATION_STOPPED: 'generation_stopped',
+      GENERATION_ENDED: 'generation_ended',
+      MESSAGE_EDITED: 'message_edited',
+      MESSAGE_SWIPED: 'message_swiped',
+      MESSAGE_UPDATED: 'message_updated',
+    },
+  };
+  globalThis.SillyTavern = { getContext: () => ctx };
+  const settings = state.getSettings(ctx);
+  settings.enabled = true;
+  settings.triggerTiming = 'after_ai';
+  state.getChatState(ctx, settings).characters['艾拉'] = {
+    name: '艾拉', initialized: true, profile: { base: {} },
+  };
+  resetGates(ctx);
+  return { ctx, settings };
+}
+
+function makeDeps() {
+  const renders = [];
+  return { deps: { renderStatusPanel() { renders.push(1); }, updateMainFlowPrompt() {} }, renders };
+}
+
+test('recordPollSkip 首报写入面板，同原因重复不再写', () => {
+  const { ctx, settings } = makeCtx();
+  const { deps, renders } = makeDeps();
+  const chatState = state.getChatState(ctx, settings);
+
+  const first = recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  assert.deepEqual(first, { skipped: true, reason: 'no_pending_history' });
+  assert.equal(chatState.lastRawResult.message, '没有新的可追踪内容，自动追踪待命中。');
+  assert.equal(renders.length, 1);
+
+  const second = recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  assert.deepEqual(second, { skipped: true, reason: 'no_pending_history' });
+  assert.equal(renders.length, 1, '同聊天同原因不重复写');
+});
+
+test('recordPollSkip 原因变化或换聊天时重新写', () => {
+  const { ctx, settings } = makeCtx();
+  const { deps, renders } = makeDeps();
+  const chatState = state.getChatState(ctx, settings);
+
+  recordPollSkip(ctx, chatState, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
+  assert.equal(renders.length, 1);
+  recordPollSkip(ctx, chatState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
+  assert.equal(renders.length, 2);
+  assert.equal(chatState.lastRawResult.message, '宿主仍在生成中，自动追踪等待中。');
+
+  const other = makeCtx('skip-report-other-chat');
+  const otherState = state.getChatState(other.ctx, other.settings);
+  recordPollSkip(other.ctx, otherState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
+  assert.equal(renders.length, 3, '换聊天重新写');
+});
+
+test('runTracker 宿主忙碌时面板留下原因', async () => {
+  const { ctx } = makeCtx();
+  const { deps } = makeDeps();
+  ctx.eventSource.emit('generation_started');
+  assert.equal(__hostRunStateForTest.generationDepth, 1);
+
+  const outcome = await runTracker(ctx, deps, 'poll');
+  assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
+  const chatState = state.getChatState(ctx, state.getSettings(ctx));
+  assert.equal(chatState.lastRawResult.message, '宿主仍在生成中，自动追踪等待中。');
+});
+
+test('poll 未启用时面板留下原因', async () => {
+  const { ctx, settings } = makeCtx();
+  settings.enabled = false;
+  const { deps } = makeDeps();
+
+  const outcome = await poll(ctx, deps);
+  assert.deepEqual(outcome, { skipped: true, reason: 'disabled' });
+  const chatState = state.getChatState(ctx, state.getSettings(ctx));
+  assert.equal(chatState.lastRawResult.message, '自动追踪未启用（在设置中开启后生效）。');
+});


### PR DESCRIPTION
## 背景

有使用者回報：**在酒館（姑且认为SillyTavern）裡游玩角色卡**時，若這張卡**沒有 MVU 腳本**，回覆後也會等很久才追蹤。（澄清一下層次：遊玩本身在酒館主窗口；角色卡的卡內腳本由**酒館助手 JS-Slash-Runner** 承載並執行，MVU 在有 MVU 的卡上就是這類卡內腳本之一，跑在酒館助手建立的 iframe 裡。）

查下來門控有兩條各自成立、又能疊加的誤判路徑：

1. **只憑設定就認定有 MVU**。MVU 把設定寫在 `SillyTavern.extensionSettings.mvu_settings`——**全局、跨卡跨聊天共享**，MVU 落盤後無人清理，所以以前玩過 MVU 卡、現在換到沒有 MVU 腳本的卡之後，設定依然在。舊碼 `if (method === '额外模型解析') everSawMvuSignal = true` 只讀設定，於是每輪白等一次寬限期。
2. **讀不到 `Mvu` 全局時反而全盤採信請求特徵**。`generateActive = !mvuCapable && generateInFlight > 0`——`mvuCapable` 為假正是「沒有 MVU」的情形，卻在那裡最信任這個啟發式訊號。只要有一個命中 `<UpdateVariable>`／`json_patch` 特徵的請求在飛（例如資料庫把聊天正文原樣轉發），就會等到 `MVU_EXTRA_MAX_WAIT_MS` 的 **120 秒上限**。**這條連「從沒裝過 MVU、也沒有任何設定殘留」的使用者都會中招。**

而 MVU 只在「優先實例」上把 `Mvu` 掛到 `window.parent`（其 `src/function/global/index.ts:172`，由 `store.should_enable` 控制；酒館助手把腳本 iframe teleport 到主文檔 body，故 iframe 的 `window.parent` 就是酒館主窗口）。所以**設定會殘留，全局不會**——這是可以拿來當判據的。

已用倉庫自身的門控模組實測確認：殘留設定＋無 `Mvu` 全局時首輪即進入等待、`everSawMvuSignal` 被置真；加上在飛請求後等 30s／119s 仍為真、**120000ms 才放行**。

## 方案

把「有 MVU」的判據從**設定**改為**全局在場**——`Mvu` 全局不在場即代表沒有激活的 MVU 實例，本輪不可能有人做額外模型解析，等下去純屬空轉。三處改動：

1. 收緊**只憑設定**的那一條武裝：`if (method === '额外模型解析') everSawMvuSignal = true` → `if (mvuPresent && method === '额外模型解析') …`（設定與全局在場須同時成立才算證據）。注意上一行 `if (mvuCapable) everSawMvuSignal = true` 本來就是看全局的，不在本次收緊範圍內。
2. 兜底訊號 `generateActive` 加上 `mvuPresent` 前提——它本來就是為**舊版 MVU**（全局在場但沒有 `isDuringExtraAnalysis` 方法）準備的，全局完全不在場時不該被第三方插件的誤命中請求牽著走。
3. 順帶清掉同源殘留：`everSawMvuSignal` 是頁面級粘性標記、生產路徑上無人清除，MVU 不在場時一併抹掉。

## 具體改動

- `scripts/tracker.js` `shouldWaitForMvuExtraAnalysis`：提前計算 `mvu = getMvuApi()` / `mvuPresent`，不在場時清 `everSawMvuSignal`；只憑設定的那條武裝加 `mvuPresent` 前提；`generateActive` 加 `mvuPresent` 前提，並更新註解說明兩個前提缺一不可。
- `tests/mvu_gate.test.mjs`：翻轉原本把「無 `Mvu` 全局＋特徵請求在飛 → 等待」斷言成期望行為的舊用例；新增「設定殘留＋無全局 → 不等待」、「舊版 MVU（全局在場、無 `isDuringExtraAnalysis`）→ 仍走兜底等待」、「不在場時粘性標記被清除」、「在場判定要認 `window.parent.Mvu`」、「`Mvu` 非物件不算在場」等用例。

## 相容性

- **新版 MVU**（有 `isDuringExtraAnalysis`）：權威訊號照舊，不在本次改動範圍。
- **舊版 MVU**（全局在場、無該方法）：兜底路徑原樣保留。
- **在酒館裡玩「沒有 MVU 腳本」的卡**（本次回報場景——注意這不是「在酒館助手里游玩」，遊玩始終在酒館主窗口）：
  - 從沒用過 MVU、無設定殘留 → 不再有任何 MVU 相關等待（第 2 條路徑被關掉）；
  - 以前玩過 MVU 卡、設定殘留 → 同樣不再等待（第 1 條路徑被關掉）。
- **「舊版 MVU 是否也掛全局」已回溯查證**：本 PR 隱含這個前提。把 MVU 倉庫（`MagicalAstrogy/MagVarUpdate`，378 個提交）的完整歷史拉下來用 pickaxe 查了三個時間點：
  - **2025-08-10**（`1845ce6`）：`src/export_globals.ts` 首次加入 `_.set(window.parent, 'Mvu', mvu)`，且當時是在 `main.ts` 裡**無條件呼叫**（尚未有 `should_enable` 閘門）；
  - **2025-10-08**（`e0f5238`）：「額外模型解析」模式（`更新方式` 枚舉）才加入；
  - **2026-01-12**（`c73a46d`）：`isDuringExtraAnalysis` 才加入。

  也就是說**凡是有「額外模型解析」的版本都已經會掛全局**（全局比該模式早約兩個月），而更早的版本連該模式都沒有、門控本來就不會武裝。故「某個舊版不掛全局導致退回不等待」這個風險**不存在**。

### 關於「全局殘留」這個條件（初稿寫錯了，此處更正）

初稿曾斷言「換卡不會摘掉 `Mvu` 全局，故一定會殘留寬限等待」。**這條是錯的**，感謝 review 指出：`pagehide` 是**每個 iframe 各自**觸發的，不是整頁卸載才有。酒館助手把卡內腳本跑在自己建的 iframe 裡（`src/panel/script/Iframe.vue`，經 `Script.vue` teleport 進主文檔 body），停用/刪除腳本、或切走擁有該腳本的角色卡／預設時，該 iframe 會被卸載 → 觸發 `pagehide` → MVU 的清理函式執行 `_.unset(window.parent, 'Mvu')`。也就是說在這些路徑上**全局確實會被摘掉**，本 PR 的「全局在場」判據成立，不會白等。因為 MVU 正是**卡內腳本**，換到沒有 MVU 腳本的卡正好落在這條卸載路徑上，所以回報場景反而最乾淨。

唯一未定的細節：MVU 的清理帶了守衛 `if (store.should_enable && _.get(window.parent, 'Mvu') === mvu)`，只有在清理那一刻 `should_enable` 仍為真時才摘除。若停用過程中該標誌先變假，全局才可能殘留。**若真發生殘留**，代價是：每輪一次寬限，且此時**不需要 `mvu_settings` 殘留**——因為 `if (mvuCapable) everSawMvuSignal = true` 是無條件武裝（初稿把前提寫窄了）。端到端延遲實測約 **7.2–9.0 秒／輪**，推導見下。

### 該情境的等待時長（實測）

用真實 `runTracker` ＋ 假時鐘量測（正文每拍都在變、之後定稿；`Mvu` 全局在場的殘留場景），從正文寫完到實際發出追蹤：

- 第一次量測：finalize 於 1801ms → **發出於 10800ms（8999ms）**；第二次 finalize 於 1799ms → **9001ms**。中間 timeline 為 `5400:waiting → 7200:waiting → 9000:waiting → 10800:send`。
- 拆解：穩定窗 `AFTER_AI_SETTLE_MS = 1400`（tracker.js:42）本身被 1800ms 的輪詢節拍量化，故從正文寫完起算約 **1.8–3.6s**；寬限 `MVU_EXTRA_WAIT_GRACE_MS = 4000`（tracker.js:60）從門控首評（＝穩定窗通過那一拍）起算，`now - pendingSince >= 4000` 要到**第 3 拍**才成立，即約 **5.4s**。
- 合計 **約 7.2–9.0 秒／輪**，且每輪重複一次。（`pollMs` 不是硬常量——實際間隔是 `Math.max(800, Number(settings.pollMs) || DEFAULT_SETTINGS.pollMs)`（tracker.js:1756），預設 1800（state.js:185），使用者可調，故上述數字以預設值為準。）
- 對照本 PR 修掉的主路徑是 **120000ms 上限**（或等完整條第三方請求鏈），量級差一個數量級；且該情境只在「本頁面會話裡 `Mvu` 全局曾經在場」時才可能出現，從沒裝過 MVU 的使用者碰不到。

要徹底消除得靠 MVU 側在停用時無條件摘掉全局、或提供「實例是否存活」的訊號（酒館助手本身沒有更可靠的判據：`getScriptTrees()` 只給配置層 `enabled`，與 `mvu_settings` 同樣陳舊）。本 PR 不再收緊，因為再進一步（例如要求「本輪真的觀測到解析」）就會碰到「MVU 尚未開始解析就先追蹤」的舊 Bug。

## 測試

- `tests/mvu_gate.test.mjs` 34/34 綠；全套 `node --test --test-timeout=30000 "tests/**/*.test.mjs"`：**426/426 綠**。
- 新用例確實攔得住回歸：把新版測試檔對舊 `scripts/tracker.js`（`074c35c`）跑，得 **30 pass / 4 fail**，紅的正是本次翻轉與新增的那幾條。
- 另派子代理獨立審查（對抗性找反例、酒館助手／MVU 生命週期核實、PR 逐條事實核對），其意見已落實：更正上述殘留情境與其時長、補上 `window.parent.Mvu` 與非物件 `Mvu` 的用例、加上粘性標記清除。
