### PR TITLE
fix: 自動追蹤不可用的三重門控問題（MVU 誤判＋靜默跳過＋dry-run 漏計數）

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ import {
   PREGNANCY_STAGE_DAYS,
   PREGNANCY_STAGES,
 } from './scripts/stage_config.js';
-import { buildMainFlowPrompt, resetPoller, runTracker } from './scripts/tracker.js';
+import { buildMainFlowPrompt, resetPoller, runTracker, getPollWaitStatus } from './scripts/tracker.js';
 import { buildLineageView, relatedNodeIds } from './scripts/lineage_view.js';
 import { deriveFetusTags, getFetusTagLabels } from './scripts/fetus_tags.js';
 import { isFetusKnownToCharacter } from './scripts/tools.js';
@@ -4933,6 +4933,11 @@ function renderStatusPanel(ctx) {
   updateBatteryIndicator(settings);
 
   list.innerHTML = '';
+  const pollWait = document.getElementById('bs-bt-track-poll-wait');
+  if (pollWait) {
+    // 轮询待命提示是暂态：只读模块级状态，不动最后一次真实追踪结果
+    pollWait.textContent = getPollWaitStatus(ctx)?.message || '';
+  }
   if (latestCall) {
     const toolCalls = Array.isArray(chatState.lastRawResult?.tool_calls) ? chatState.lastRawResult.tool_calls : [];
     const characterChecks = Array.isArray(chatState.lastRawResult?.character_checks) ? chatState.lastRawResult.character_checks : [];

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -1589,22 +1589,35 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
 /**
  * 轮询跳过原因显形：下面几条自动独有的早退原本全程静默，面板停在旧结果上，
  * 使用者分不清「已追完」「正在等」还是「被某道门卡死」（自动不可用、手动可用
- * 时只能瞎猜）。只在「同聊天＋同原因」变化时写一次，避免每 1.8 秒刷一次
- * 持久化与面板；追踪一旦真正跑起来，结果会照常覆盖这里。
+ * 时只能瞎猜）。状态放在模块级 Map 里按聊天隔离，天然暂态：不进 chatState、
+ * 不持久化、不进快照，更不改写 lastRawResult／lastOperationLogs——成功追踪的
+ * 结果不会被下一轮待命 poll 冲掉。同聊天＋同原因＋同文案＋同来源才去重，
+ * 忙碌来源切换（停止按钮→事件计数）或层数变化都会刷新提示。
  */
-const lastPollSkipReport = { chatKey: '', reason: '' };
-export const __pollSkipReportForTest = lastPollSkipReport;
+const pollWaitByChat = new Map();
+export const __pollWaitByChatForTest = pollWaitByChat;
 
-export function recordPollSkip(ctx, chatState, deps, reason, message) {
+export function getPollWaitStatus(ctx) {
+  return pollWaitByChat.get(String(getChatKey(ctx) || '')) || null;
+}
+
+export function clearPollWaitStatus(ctx) {
+  pollWaitByChat.delete(String(getChatKey(ctx) || ''));
+}
+
+export function recordPollSkip(ctx, deps, reason, message, opts = {}) {
   const chatKey = String(getChatKey(ctx) || '');
-  if (lastPollSkipReport.chatKey === chatKey && lastPollSkipReport.reason === reason) {
+  const source = String(opts?.source || '');
+  const prev = pollWaitByChat.get(chatKey);
+  if (prev && prev.reason === reason && prev.message === message && prev.source === source) {
+    prev.updatedAt = Date.now();
     return { skipped: true, reason };
   }
-  lastPollSkipReport.chatKey = chatKey;
-  lastPollSkipReport.reason = reason;
-  chatState.lastRawResult = { message, tool_calls: [] };
-  chatState.lastOperationLogs = [];
-  saveSettings(ctx);
+  pollWaitByChat.set(chatKey, { reason, message, source, updatedAt: Date.now() });
+  // 按聊天隔离的暂态条目：聊天数有界，换聊天只保留最近若干个
+  while (pollWaitByChat.size > 50) {
+    pollWaitByChat.delete(pollWaitByChat.keys().next().value);
+  }
   deps.renderStatusPanel(ctx);
   return { skipped: true, reason };
 }
@@ -1621,6 +1634,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
   const chat = getHostChat(ctx);
   const lastMessage = chat[chat.length - 1];
   if (!lastMessage) {
+    clearPollWaitStatus(ctx);
     chatState.lastRawResult = {
       message: '当前对话没有可分析的消息，已跳过追踪。',
       tool_calls: [],
@@ -1632,6 +1646,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
   }
   if (globalThis[RUN_RUNTIME_KEY]) {
     if (!isTrackerRunStale(settings)) {
+      clearPollWaitStatus(ctx);
       chatState.lastRawResult = {
         message: '已有一轮追踪请求正在执行，本次请求未重复发送。',
         tool_calls: [],
@@ -1645,6 +1660,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     globalThis[RUN_RUNTIME_KEY] = null;
   }
   if (registeredTargets.length === 0) {
+    clearPollWaitStatus(ctx);
     chatState.lastRawResult = {
       message: '尚无已注册角色，跳过分析。',
       tool_calls: [],
@@ -1656,6 +1672,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     return { skipped: true, reason: 'no_registered_targets' };
   }
   if (reason === 'poll' && getHostKind() === 'luker' && settings.lukerMultiAgentManualOnly !== false) {
+    clearPollWaitStatus(ctx);
     chatState.lastRawResult = {
       message: 'Luker 多智能体安全模式已开启，自动追踪暂停；请在编排完成后手动分析。',
       tool_calls: [],
@@ -1673,60 +1690,61 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     if (busyDetail.busy) {
       return recordPollSkip(
         ctx,
-        chatState,
         deps,
         'host_generation_in_flight',
         busyDetail.source === 'depth'
           ? `宿主生成事件未闭合（${Number(busyDetail.depth) || 0} 层），自动追踪等待中。`
           : '宿主仍在生成中（停止按钮未释放），自动追踪等待中。',
+        { source: busyDetail.source || '' },
       );
     }
   }
   if (reason === 'poll') {
     const agentBarrier = await getHostAgentRunBarrier(ctx, lastMessage);
     if (agentBarrier.state === 'pending') {
-      chatState.lastRawResult = {
-        message: `TauriTavern Agent run ${agentBarrier.runId} 尚未完成，自动追踪将等待最终提交。`,
-        tool_calls: [],
-      };
-      chatState.lastOperationLogs = [];
-      saveSettings(ctx);
-      deps.renderStatusPanel(ctx);
-      return { skipped: true, reason: 'agent_run_pending' };
+      return recordPollSkip(
+        ctx,
+        deps,
+        'agent_run_pending',
+        `TauriTavern Agent run ${agentBarrier.runId} 尚未完成，自动追踪将等待最终提交。`,
+        { source: 'agent' },
+      );
     }
     if (agentBarrier.state === 'aborted') {
-      chatState.lastRawResult = {
-        message: `TauriTavern Agent run ${agentBarrier.runId} 已取消或失败，未自动追踪该提交；可手动分析。`,
-        tool_calls: [],
-      };
-      chatState.lastOperationLogs = [];
-      saveSettings(ctx);
-      deps.renderStatusPanel(ctx);
-      return { skipped: true, reason: 'agent_run_aborted' };
+      return recordPollSkip(
+        ctx,
+        deps,
+        'agent_run_aborted',
+        `TauriTavern Agent run ${agentBarrier.runId} 已取消或失败，未自动追踪该提交；可手动分析。`,
+        { source: 'agent' },
+      );
     }
   }
   if (reason === 'poll' && !isAfterAiMessageSettled(ctx, settings, chatState)) {
-    return recordPollSkip(ctx, chatState, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
+    return recordPollSkip(ctx, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
   }
   if (reason === 'poll' && !hasPendingChatHistory(ctx, chatState)) {
-    return recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+    return recordPollSkip(ctx, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
   }
   if (reason === 'poll' && shouldWaitForMvuExtraAnalysis(ctx, settings)) {
-    return recordPollSkip(ctx, chatState, deps, 'waiting_mvu_extra_analysis', '等待 MVU 额外解析结束后再追踪。');
+    return recordPollSkip(ctx, deps, 'waiting_mvu_extra_analysis', '等待 MVU 额外解析结束后再追踪。');
   }
   if (reason === 'poll' && tryAdoptSilentTailReplacement(ctx, settings, chatState)) {
-    // 正文替换的无痕改写：静默重锚，不发请求也不弹任何提示
+    // 正文替换的无痕改写：静默重锚，不发请求也不弹任何提示；上一轮待命提示作废
+    clearPollWaitStatus(ctx);
+    deps.renderStatusPanel(ctx);
     return { skipped: true, reason: 'silent_tail_replacement' };
   }
   if (reason === 'poll' && isFailedAutoRetryBlocked(ctx, chatState)) {
     return recordPollSkip(
       ctx,
-      chatState,
       deps,
       'failed_message_blocked',
       '上次自动追踪失败，对话无变化时暂停自动重试；可手动分析或等待新消息。',
     );
   }
+  // 门控全部通过、真正要干活了：上一轮待命的暂态提示作废，后续面板只展示真实结果
+  clearPollWaitStatus(ctx);
   const runToken = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   globalThis[RUN_RUNTIME_KEY] = runToken;
   markTrackerRunProgress();
@@ -1768,6 +1786,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     // 记下失败当下「整段对话」的签名：只要对话没变，自动重试就该被挡住。
     // 失败可能发生在回放的中间楼，只比对尾楼会让轮询无限重发。
     chatState.lastFailedChatSignature = buildSignature(ctx, getHostChat(ctx).length);
+    clearPollWaitStatus(ctx);
     chatState.lastRawResult = {
       error: String(error?.message || error),
       tool_calls: [],
@@ -1793,7 +1812,6 @@ export async function poll(ctx, deps) {
   if (!settings.enabled) {
     return recordPollSkip(
       ctx,
-      getChatState(ctx, settings),
       deps,
       'disabled',
       '自动追踪未启用（在设置中开启后生效）。',

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -420,7 +420,12 @@ function resolveHostEventName(ctx, typeKey, fallback) {
   return typeof resolved === 'string' && resolved ? resolved : fallback;
 }
 
-function markHostGenerationStart() {
+function markHostGenerationStart(...args) {
+  // dry-run（token 计数拼 prompt）只发 STARTED 不发 ENDED：按钮从没显示过，
+  // 两家宿主 hideStopButton 的 NOOP 守卫都会吞掉 ENDED。计入深度等于把自动追踪
+  // 卡到 600 秒自愈。两家 STARTED 的最后一个事件参数都是 dryRun（ST/TT 一致），
+  // 只在这个确切形状下跳过，其它一律照计。
+  if (args.length > 0 && args[args.length - 1] === true) return;
   hostRunState.generationDepth += 1;
   if (hostRunState.generationDepth === 1) hostRunState.generationBusySince = Date.now();
 }

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -1574,6 +1574,29 @@ async function processTrackerMessage(ctx, settings, chatState, deps, reason, mes
   return { discarded: false, triggered: true };
 }
 
+/**
+ * 轮询跳过原因显形：下面几条自动独有的早退原本全程静默，面板停在旧结果上，
+ * 使用者分不清「已追完」「正在等」还是「被某道门卡死」（自动不可用、手动可用
+ * 时只能瞎猜）。只在「同聊天＋同原因」变化时写一次，避免每 1.8 秒刷一次
+ * 持久化与面板；追踪一旦真正跑起来，结果会照常覆盖这里。
+ */
+const lastPollSkipReport = { chatKey: '', reason: '' };
+export const __pollSkipReportForTest = lastPollSkipReport;
+
+export function recordPollSkip(ctx, chatState, deps, reason, message) {
+  const chatKey = String(getChatKey(ctx) || '');
+  if (lastPollSkipReport.chatKey === chatKey && lastPollSkipReport.reason === reason) {
+    return { skipped: true, reason };
+  }
+  lastPollSkipReport.chatKey = chatKey;
+  lastPollSkipReport.reason = reason;
+  chatState.lastRawResult = { message, tool_calls: [] };
+  chatState.lastOperationLogs = [];
+  saveSettings(ctx);
+  deps.renderStatusPanel(ctx);
+  return { skipped: true, reason };
+}
+
 export async function runTracker(ctx, deps, reason = 'manual') {
   const settings = getSettings(ctx);
   await hydrateChatStateFromHost(ctx, settings);
@@ -1632,7 +1655,7 @@ export async function runTracker(ctx, deps, reason = 'manual') {
   }
   if (reason === 'poll' && isHostGenerationBusy(ctx)) {
     // 主连接没说完话就绝不追踪：从根上消灭「开始吐字时抢发一轮」
-    return { skipped: true, reason: 'host_generation_in_flight' };
+    return recordPollSkip(ctx, chatState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
   }
   if (reason === 'poll') {
     const agentBarrier = await getHostAgentRunBarrier(ctx, lastMessage);
@@ -1658,20 +1681,26 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     }
   }
   if (reason === 'poll' && !isAfterAiMessageSettled(ctx, settings, chatState)) {
-    return { skipped: true, reason: 'message_not_settled' };
+    return recordPollSkip(ctx, chatState, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
   }
   if (reason === 'poll' && !hasPendingChatHistory(ctx, chatState)) {
-    return { skipped: true, reason: 'no_pending_history' };
+    return recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
   }
   if (reason === 'poll' && shouldWaitForMvuExtraAnalysis(ctx, settings)) {
-    return { skipped: true, reason: 'waiting_mvu_extra_analysis' };
+    return recordPollSkip(ctx, chatState, deps, 'waiting_mvu_extra_analysis', '等待 MVU 额外解析结束后再追踪。');
   }
   if (reason === 'poll' && tryAdoptSilentTailReplacement(ctx, settings, chatState)) {
     // 正文替换的无痕改写：静默重锚，不发请求也不弹任何提示
     return { skipped: true, reason: 'silent_tail_replacement' };
   }
   if (reason === 'poll' && isFailedAutoRetryBlocked(ctx, chatState)) {
-    return { skipped: true, reason: 'failed_message_blocked' };
+    return recordPollSkip(
+      ctx,
+      chatState,
+      deps,
+      'failed_message_blocked',
+      '上次自动追踪失败，对话无变化时暂停自动重试；可手动分析或等待新消息。',
+    );
   }
   const runToken = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   globalThis[RUN_RUNTIME_KEY] = runToken;
@@ -1736,7 +1765,15 @@ export async function runTracker(ctx, deps, reason = 'manual') {
 
 export async function poll(ctx, deps) {
   const settings = getSettings(ctx);
-  if (!settings.enabled) return;
+  if (!settings.enabled) {
+    return recordPollSkip(
+      ctx,
+      getChatState(ctx, settings),
+      deps,
+      'disabled',
+      '自动追踪未启用（在设置中开启后生效）。',
+    );
+  }
   await runTracker(ctx, deps, 'poll');
 }
 

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -288,6 +288,14 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
   // fetch 钩子必须在首次评估前就装好：否则正文后第一时间启动的 MVU 请求会被漏观测
   installMvuFetchHook();
 
+  // MVU 只在「优先实例」上把 Mvu 挂到 window.parent（见其 store 的 should_enable），
+  // 所以全局不在场＝本轮没有激活的 MVU 实例＝不会有人做额外模型解析。
+  const mvu = getMvuApi();
+  const mvuPresent = mvu !== null;
+  // 不在场就抹掉「见过 MVU 信号」的记忆：该标记是页面级粘性、生产路径上无人清除，
+  // 停用 MVU 或换到没有 MVU 的卡之后它仍为真，会让每一轮都白等一次宽限期。
+  if (!mvuPresent) mvuGateState.everSawMvuSignal = false;
+
   const mvuSettings = getMvuSettings(ctx);
   const method = mvuSettings?.更新方式;
   // 能读到设置且明确是随AI输出 → 不需要等待
@@ -297,12 +305,16 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
     const autoRequest = mvuSettings?.额外模型解析配置?.启用自动请求 ?? mvuSettings?.自动触发额外模型解析;
     if (autoRequest === false) return false;
   }
-  const mvu = getMvuApi();
-  const mvuCapable = mvu && typeof mvu.isDuringExtraAnalysis === 'function';
+  // 设置是会话无关的持久态，会残留：mvu_settings 存在 SillyTavern.extensionSettings
+  // （全局、跨卡跨聊天共享、MVU 落盘后无人清理），停用 MVU 或换到没有 MVU 的卡之后
+  // 它依然在。只凭设置就认定「本环境有 MVU」，会把这类用户当成 MVU 用户——每轮白等
+  // 宽限期，并让下面的 fetch 兜底信号生效（最长 120 秒）。故设置须与「全局在场」同时
+  // 成立才算证据。
+  const mvuCapable = Boolean(mvu && typeof mvu.isDuringExtraAnalysis === 'function');
   // 三种信号源全部不可用（fetch 被禁用、无 Mvu、设置读不到）→ 无从判断
   if (!mvuGateState.fetchHooked && !mvuCapable && method !== '额外模型解析') return false;
   if (mvuCapable) mvuGateState.everSawMvuSignal = true;
-  if (method === '额外模型解析') mvuGateState.everSawMvuSignal = true;
+  if (mvuPresent && method === '额外模型解析') mvuGateState.everSawMvuSignal = true;
 
   installMvuGateListener(ctx);
   const roundKey = getMvuRoundKey(ctx);
@@ -328,12 +340,12 @@ export function shouldWaitForMvuExtraAnalysis(ctx, _settings) {
 
   // 信号 1：MVU 全局 API 报告正在解析
   const during = mvuCapable && mvu.isDuringExtraAnalysis() === true;
-  // 信号 2：正文之后仍有非本插件的生成请求在飞行——仅作旧版 MVU（没有
-  // isDuringExtraAnalysis 全局）的兜底。请求特征会被误命中：数据库正文替换/
-  // 填表的请求体嵌着含 <UpdateVariable>、json_patch 字样的正文与提示词，全局
-  // 标志可得时不再采信它，否则兼容门控会串行等完数据库一整条后处理管线
-  // （TT 实测一分钟以上的延迟）。
-  const generateActive = !mvuCapable && mvuGateState.generateInFlight > 0;
+  // 信号 2：正文之后仍有非本插件的生成请求在飞行——仅作旧版 MVU（全局在场但它
+  // 没有 isDuringExtraAnalysis 方法）的兜底。请求特征会被误命中：数据库正文替换/
+  // 填表的请求体嵌着含 <UpdateVariable>、json_patch 字样的正文与提示词。
+  // 两个前提缺一不可：只有全局在场才说明真有 MVU 可能在做解析（否则没人会解析，
+  // 等下去纯属空转），且只有带不了权威标志的旧版才需要退而采信请求特征。
+  const generateActive = mvuPresent && !mvuCapable && mvuGateState.generateInFlight > 0;
   // 生成请求只作为本轮「在飞」等待信号，不参与 everSawMvuSignal——
   // 否则普通 ST 主流请求也会让设备被标记为「见过 MVU 信号」，导致每轮白等宽限
   if (during) mvuGateState.everSawMvuSignal = true;

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -507,8 +507,11 @@ function hostDatasetGenerating() {
  * 的等待由既有的兼容门控 shouldWaitForMvuExtraAnalysis 负责（TT 上它走带停止
  * 按钮的 Generate 管线，dataset 信号同样会覆盖其在飞阶段），兼容开关语义不动。
  */
-export function isHostGenerationBusy(ctx) {
-  if (hostDatasetGenerating()) return true;
+export function getHostBusyDetail(ctx) {
+  void ctx;
+  // dataset 旗标是停止按钮的权威状态，没有超时自愈：真在生成时必须等，
+  // 卡死时则会一直挡——面板上要能区分它和事件计数
+  if (hostDatasetGenerating()) return { busy: true, source: 'dataset' };
   if (hostRunState.generationDepth > 0) {
     const staleMs = Number(globalThis[HOST_BUSY_STALE_MS_KEY]) || 600000;
     if (Date.now() - hostRunState.generationBusySince > staleMs) {
@@ -516,10 +519,14 @@ export function isHostGenerationBusy(ctx) {
       hostRunState.generationDepth = 0;
       hostRunState.generationBusySince = 0;
     } else {
-      return true;
+      return { busy: true, source: 'depth', depth: hostRunState.generationDepth };
     }
   }
-  return false;
+  return { busy: false, source: '' };
+}
+
+export function isHostGenerationBusy(ctx) {
+  return getHostBusyDetail(ctx).busy;
 }
 
 /** 楼层上正文替换盖的毫秒时间戳；没盖过返回 0。 */
@@ -1653,9 +1660,22 @@ export async function runTracker(ctx, deps, reason = 'manual') {
     deps.renderStatusPanel(ctx);
     return { skipped: true, reason: 'luker_multi_agent_manual' };
   }
-  if (reason === 'poll' && isHostGenerationBusy(ctx)) {
-    // 主连接没说完话就绝不追踪：从根上消灭「开始吐字时抢发一轮」
-    return recordPollSkip(ctx, chatState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
+  if (reason === 'poll') {
+    // 主连接没说完话就绝不追踪：从根上消灭「开始吐字时抢发一轮」。
+    // 两路信号分开展示：dataset 是停止按钮的权威状态（无自愈，卡死会一直挡），
+    // depth 是生成事件计数（600 秒自愈）。「卡在正文生成阶段」时面板直接指明是哪一路。
+    const busyDetail = getHostBusyDetail(ctx);
+    if (busyDetail.busy) {
+      return recordPollSkip(
+        ctx,
+        chatState,
+        deps,
+        'host_generation_in_flight',
+        busyDetail.source === 'depth'
+          ? `宿主生成事件未闭合（${Number(busyDetail.depth) || 0} 层），自动追踪等待中。`
+          : '宿主仍在生成中（停止按钮未释放），自动追踪等待中。',
+      );
+    }
   }
   if (reason === 'poll') {
     const agentBarrier = await getHostAgentRunBarrier(ctx, lastMessage);

--- a/settings.html
+++ b/settings.html
@@ -584,6 +584,7 @@
 
             <div class="settings_section">
               <div class="bs-bt-status-title">最新工具调用</div>
+              <div id="bs-bt-track-poll-wait" class="bs-bt-inline-status"></div>
               <div id="bs-bt-track-last-call" class="bs-bt-status-box">尚无数据</div>
             </div>
 

--- a/tests/mvu_gate.test.mjs
+++ b/tests/mvu_gate.test.mjs
@@ -264,17 +264,74 @@ test('额外模型解析但自动请求关闭 → 门控直接放行', () => {
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), false);
 });
 
-test('TT 场景：读不到设置、无 Mvu，但确认是 MVU 额外解析请求在飞行 → 等待', () => {
+test('完全没有 Mvu 全局时，特征请求在飞也不等待（第三方插件误命中不再空等）', () => {
   resetGate();
   const ctx = makeCtx(); // 无 mvu_settings、无 Mvu 全局
   const settings = makeSettings();
   // 首次评估：未看到信号
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
-  // MVU 的额外解析请求开始飞行（fetch 钩子观测到）
+  // 某个第三方插件（数据库正文替换/填表转发聊天正文）的请求命中 MVU 特征、在飞行：
+  // 没有激活的 MVU 实例就不会有人解析变量（MVU 只在优先实例上挂 window.parent.Mvu），
+  // 此时等待纯属空转——这正是无 MVU 用户被拖住的历史路径
   __mvuGateStateForTest.generateInFlight = 1;
   __mvuGateStateForTest.lastGenerateStartedAt = Date.now();
   __mvuGateStateForTest.sawGenerateThisRound = true;
-  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('回归：停用 MVU 后 mvu_settings 残留、Mvu 全局不在场 → 不等待', () => {
+  resetGate();
+  // MVU 把设置写在 SillyTavern.extensionSettings.mvu_settings（全局、跨卡共享、
+  // 无人清理），所以换到没有 MVU 的卡或停用 MVU 后设置仍在；而 Mvu 全局会随
+  // 优先实例缺席而不在场。只凭设置就等待，会让这类用户每轮白等宽限期。
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  const settings = makeSettings();
+  assert.equal(globalThis.Mvu, undefined, '前提：没有 Mvu 全局');
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false, '设置残留不应单独构成等待理由');
+  assert.equal(
+    __mvuGateStateForTest.everSawMvuSignal,
+    false,
+    '残留设置不得把设备标记为「见过 MVU 信号」（否则之后每轮都白等宽限）',
+  );
+  // 即便有特征请求在飞也照样放行：没有 MVU 实例，没人会解析
+  __mvuGateStateForTest.generateInFlight = 1;
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('旧版 MVU：全局在场但没有 isDuringExtraAnalysis → 仍按请求特征兜底等待', () => {
+  resetGate();
+  // 旧版 MVU 只暴露 Mvu 全局、没有权威的解析状态方法
+  globalThis.Mvu = { getMvuData: () => ({}) };
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  const settings = makeSettings();
+  __mvuGateStateForTest.generateInFlight = 1;
+  __mvuGateStateForTest.lastGenerateStartedAt = Date.now();
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true, '旧版兜底路径必须保留');
+  __mvuGateStateForTest.generateInFlight = 0;
+  __mvuGateStateForTest.pendingSince = Date.now() - 5000;
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('在场判定要认 window.parent.Mvu（MVU 跑在酒馆助手 iframe 时挂在父窗口）', () => {
+  resetGate();
+  // MVU 作为酒馆助手脚本运行在 iframe，把全局挂到 window.parent；本插件若也在
+  // iframe 之外的上下文里取，就必须认这条分支——门控现在以「全局在场」为门槛
+  globalThis.parent = { Mvu: { isDuringExtraAnalysis: () => true } };
+  try {
+    const ctx = makeCtx();
+    assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), true, 'parent 上的 Mvu 应被认作在场');
+  } finally {
+    delete globalThis.parent;
+  }
+});
+
+test('Mvu 全局不是对象时不算在场（不放行出兜底等待）', () => {
+  resetGate();
+  // getMvuApi 只认对象；万一 MVU 暴露成函数或原始值，不能当作「有 MVU」
+  globalThis.Mvu = () => {};
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, makeSettings()), false);
+  assert.equal(__mvuGateStateForTest.everSawMvuSignal, false);
 });
 
 test('fetch 钩子只认 MVU 特征请求：普通 ST 主线生成不触发（误报回归）', () => {
@@ -378,6 +435,8 @@ test('端到端：MVU 额外解析请求经过真实 fetch 钩子触发等待', 
 
 test('生成请求结束后放行', () => {
   resetGate();
+  // 走旧版兜底路径：全局在场（才有解析可能）但没有权威状态方法
+  globalThis.Mvu = { getMvuData: () => ({}) };
   const ctx = makeCtx();
   const settings = makeSettings();
   // 请求在飞行 → 等待
@@ -386,11 +445,14 @@ test('生成请求结束后放行', () => {
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), true);
   // 请求完成 → 放行（MVU 变量已更新）
   __mvuGateStateForTest.generateInFlight = 0;
+  __mvuGateStateForTest.pendingSince = Date.now() - 5000;
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
 });
 
 test('见过 MVU 信号后，无信号轮次走宽限期等待', () => {
   resetGate();
+  // MVU 在场（没有权威状态方法，走旧版兜底那条）
+  globalThis.Mvu = { getMvuData: () => ({}) };
   const ctx = makeCtx();
   const settings = makeSettings();
   // 之前某轮见过生成请求（everSaw 为 true）
@@ -400,6 +462,17 @@ test('见过 MVU 信号后，无信号轮次走宽限期等待', () => {
   // 超过宽限期仍未出现信号 → 放行
   __mvuGateStateForTest.pendingSince = Date.now() - 5000;
   assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+});
+
+test('MVU 不在场时粘性标记被清除：停用/换卡后不再每轮白等宽限', () => {
+  resetGate();
+  const ctx = makeCtx({ extensionSettings: { mvu_settings: makeMvuSettings() } });
+  const settings = makeSettings();
+  // 模拟本页早先见过 MVU 信号、之后 MVU 消失（停用脚本或换到无 MVU 的卡）
+  __mvuGateStateForTest.everSawMvuSignal = true;
+  assert.equal(globalThis.Mvu, undefined, '前提：此刻没有 Mvu 全局');
+  assert.equal(shouldWaitForMvuExtraAnalysis(ctx, settings), false);
+  assert.equal(__mvuGateStateForTest.everSawMvuSignal, false, '不在场时应抹掉记忆，下一轮才不会再白等');
 });
 
 test('mainflow 快照绑定当前聊天：跨聊天/无绑定一律拒绝', () => {

--- a/tests/poll_skip_report.test.mjs
+++ b/tests/poll_skip_report.test.mjs
@@ -152,3 +152,29 @@ test('poll 未启用时面板留下原因', async () => {
   const chatState = state.getChatState(ctx, state.getSettings(ctx));
   assert.equal(chatState.lastRawResult.message, '自动追踪未启用（在设置中开启后生效）。');
 });
+
+test('dry-run 的 generation_started 不计入忙碌（宿主只发 STARTED 不发 ENDED）', async () => {
+  const { ctx } = makeCtx();
+  const { deps } = makeDeps();
+  // 两家宿主的 dry-run（token 计数）都带 dryRun=true 尾参，且从不显示停止按钮，
+  // hideStopButton 的 NOOP 守卫会吞掉 ENDED；计入就等于卡到 600 秒自愈
+  ctx.eventSource.emit('generation_started', 'quiet', { quiet_prompt: '计数' }, true);
+  assert.equal(__hostRunStateForTest.generationDepth, 0, 'dry-run 不得计数');
+  ctx.eventSource.emit('generation_started', 'quiet', { quiet_prompt: '计数' }, true);
+  assert.equal(__hostRunStateForTest.generationDepth, 0, '多次 dry-run 也不得累积');
+
+  const outcome = await runTracker(ctx, deps, 'poll');
+  assert.notEqual(outcome?.reason, 'host_generation_in_flight', 'dry-run 不得挡住自动追踪');
+});
+
+test('dry-run 之后真生成仍照常计数', async () => {
+  const { ctx } = makeCtx();
+  const { deps } = makeDeps();
+  ctx.eventSource.emit('generation_started', 'quiet', {}, true);
+  assert.equal(__hostRunStateForTest.generationDepth, 0);
+  ctx.eventSource.emit('generation_started', 'normal', {});
+  assert.equal(__hostRunStateForTest.generationDepth, 1);
+
+  const outcome = await runTracker(ctx, deps, 'poll');
+  assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
+});

--- a/tests/poll_skip_report.test.mjs
+++ b/tests/poll_skip_report.test.mjs
@@ -1,11 +1,14 @@
 // 轮询跳过原因显形：自动独有的静默早退必须在面板留下原因，
-// 否则“自动不可用、手动可用”时无从定位。只在原因变化时写一次。
+// 否则“自动不可用、手动可用”时无从定位。状态是模块级暂态，
+// 不改写最后一次真实追踪结果；同聊天＋同原因＋同文案＋同来源才去重。
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import * as state from '../scripts/state.js';
 import {
-  __pollSkipReportForTest,
+  __pollWaitByChatForTest,
+  clearPollWaitStatus,
+  getPollWaitStatus,
   poll,
   recordPollSkip,
   runTracker,
@@ -45,8 +48,7 @@ function resetGates(ctx) {
   gate.lastGenerateStartedAt = 0;
   gate.sawGenerateThisRound = false;
   gate.everSawMvuSignal = false;
-  __pollSkipReportForTest.chatKey = '';
-  __pollSkipReportForTest.reason = '';
+  __pollWaitByChatForTest.clear();
   delete globalThis.Mvu;
   delete globalThis.document;
   if (ctx?.eventSource) installHostRunWatchers(ctx);
@@ -84,48 +86,57 @@ function makeDeps() {
   return { deps: { renderStatusPanel() { renders.push(1); }, updateMainFlowPrompt() {} }, renders };
 }
 
-test('recordPollSkip 首报写入面板，同原因重复不再写', () => {
+test('recordPollSkip 首报写入暂态，不动最后一次真实结果', () => {
   const { ctx, settings } = makeCtx();
   const { deps, renders } = makeDeps();
   const chatState = state.getChatState(ctx, settings);
+  chatState.lastRawResult = { message: '真实追踪结果', tool_calls: [{ name: 'bsSetCharacterPresence' }] };
+  chatState.lastOperationLogs = [{ name: 'bsSetCharacterPresence', applied: true }];
 
-  const first = recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  const first = recordPollSkip(ctx, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
   assert.deepEqual(first, { skipped: true, reason: 'no_pending_history' });
-  assert.equal(chatState.lastRawResult.message, '没有新的可追踪内容，自动追踪待命中。');
+  assert.equal(getPollWaitStatus(ctx)?.message, '没有新的可追踪内容，自动追踪待命中。');
+  assert.equal(chatState.lastRawResult.message, '真实追踪结果', '待命提示不得冲掉真实结果');
+  assert.equal(chatState.lastOperationLogs.length, 1, '执行日志不得被清空');
   assert.equal(renders.length, 1);
 
-  const second = recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  const second = recordPollSkip(ctx, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
   assert.deepEqual(second, { skipped: true, reason: 'no_pending_history' });
-  assert.equal(renders.length, 1, '同聊天同原因不重复写');
+  assert.equal(renders.length, 1, '同聊天同原因同文案不重复渲染');
 });
 
-test('recordPollSkip 原因变化或换聊天时重新写', () => {
-  const { ctx, settings } = makeCtx();
+test('recordPollSkip 文案或来源变化时刷新（同原因也刷新）', () => {
+  const { ctx } = makeCtx();
   const { deps, renders } = makeDeps();
-  const chatState = state.getChatState(ctx, settings);
 
-  recordPollSkip(ctx, chatState, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
+  recordPollSkip(ctx, deps, 'host_generation_in_flight', '宿主生成事件未闭合（1 层），自动追踪等待中。', { source: 'depth' });
   assert.equal(renders.length, 1);
-  recordPollSkip(ctx, chatState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
+  // 同原因、层数变化 → 文案变化，必须刷新
+  recordPollSkip(ctx, deps, 'host_generation_in_flight', '宿主生成事件未闭合（2 层），自动追踪等待中。', { source: 'depth' });
   assert.equal(renders.length, 2);
-  assert.equal(chatState.lastRawResult.message, '宿主仍在生成中，自动追踪等待中。');
+  assert.match(getPollWaitStatus(ctx)?.message || '', /2 层/);
+  // 同原因同文案、来源切换（事件计数→停止按钮）→ 必须刷新
+  recordPollSkip(ctx, deps, 'host_generation_in_flight', '宿主生成事件未闭合（2 层），自动追踪等待中。', { source: 'dataset' });
+  assert.equal(renders.length, 3);
 
   const other = makeCtx('skip-report-other-chat');
-  const otherState = state.getChatState(other.ctx, other.settings);
-  recordPollSkip(other.ctx, otherState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
-  assert.equal(renders.length, 3, '换聊天重新写');
+  recordPollSkip(other.ctx, deps, 'host_generation_in_flight', '宿主生成事件未闭合（2 层），自动追踪等待中。', { source: 'depth' });
+  assert.equal(renders.length, 4, '换聊天重新写');
 });
 
-test('runTracker 宿主忙碌时面板留下原因（事件计数一路）', async () => {
-  const { ctx } = makeCtx();
+test('runTracker 宿主忙碌时面板留下原因（事件计数一路），不动真实结果', async () => {
+  const { ctx, settings } = makeCtx();
   const { deps } = makeDeps();
+  const chatState = state.getChatState(ctx, settings);
+  chatState.lastRawResult = { message: '真实追踪结果', tool_calls: [] };
   ctx.eventSource.emit('generation_started');
   assert.equal(__hostRunStateForTest.generationDepth, 1);
 
   const outcome = await runTracker(ctx, deps, 'poll');
   assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
-  const chatState = state.getChatState(ctx, state.getSettings(ctx));
-  assert.equal(chatState.lastRawResult.message, '宿主生成事件未闭合（1 层），自动追踪等待中。');
+  assert.equal(getPollWaitStatus(ctx)?.message, '宿主生成事件未闭合（1 层），自动追踪等待中。');
+  assert.equal(getPollWaitStatus(ctx)?.source, 'depth');
+  assert.equal(chatState.lastRawResult.message, '真实追踪结果');
 });
 
 test('runTracker 宿主忙碌时面板留下原因（停止按钮旗标一路）', async () => {
@@ -135,22 +146,58 @@ test('runTracker 宿主忙碌时面板留下原因（停止按钮旗标一路）
   try {
     const outcome = await runTracker(ctx, deps, 'poll');
     assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
-    const chatState = state.getChatState(ctx, state.getSettings(ctx));
-    assert.equal(chatState.lastRawResult.message, '宿主仍在生成中（停止按钮未释放），自动追踪等待中。');
+    assert.equal(getPollWaitStatus(ctx)?.message, '宿主仍在生成中（停止按钮未释放），自动追踪等待中。');
+    assert.equal(getPollWaitStatus(ctx)?.source, 'dataset');
   } finally {
     delete globalThis.document;
   }
 });
 
-test('poll 未启用时面板留下原因', async () => {
+test('poll 未启用时面板留下原因，不动真实结果', async () => {
   const { ctx, settings } = makeCtx();
   settings.enabled = false;
   const { deps } = makeDeps();
+  const chatState = state.getChatState(ctx, settings);
+  chatState.lastRawResult = { message: '真实追踪结果', tool_calls: [] };
 
   const outcome = await poll(ctx, deps);
   assert.deepEqual(outcome, { skipped: true, reason: 'disabled' });
-  const chatState = state.getChatState(ctx, state.getSettings(ctx));
-  assert.equal(chatState.lastRawResult.message, '自动追踪未启用（在设置中开启后生效）。');
+  assert.equal(getPollWaitStatus(ctx)?.message, '自动追踪未启用（在设置中开启后生效）。');
+  assert.equal(chatState.lastRawResult.message, '真实追踪结果');
+});
+
+test('clearPollWaitStatus 清掉暂态提示（真实开跑后调用）', () => {
+  const { ctx } = makeCtx();
+  const { deps } = makeDeps();
+  recordPollSkip(ctx, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  assert.ok(getPollWaitStatus(ctx));
+  clearPollWaitStatus(ctx);
+  assert.equal(getPollWaitStatus(ctx), null);
+});
+
+test('早退改写 lastRawResult 时旧待命提示一并清除', async () => {
+  const { ctx, settings } = makeCtx();
+  const { deps } = makeDeps();
+  recordPollSkip(ctx, deps, 'host_generation_in_flight', '宿主生成事件未闭合（1 层），自动追踪等待中。', { source: 'depth' });
+  assert.ok(getPollWaitStatus(ctx));
+  ctx.chat = [];
+  const outcome = await runTracker(ctx, deps, 'poll');
+  assert.deepEqual(outcome, { skipped: true, reason: 'empty_chat' });
+  const chatState = state.getChatState(ctx, settings);
+  assert.equal(chatState.lastRawResult.message, '当前对话没有可分析的消息，已跳过追踪。');
+  assert.equal(getPollWaitStatus(ctx), null, '旧等待行不得压在新结果上');
+});
+
+test('暂态按聊天隔离，只保留最近若干个', () => {
+  const { deps } = makeDeps();
+  // 直接用最小 ctx：makeCtx 自带 resetGates 会清空 Map，不适合测淘汰
+  const first = { chatId: 'skip-report-evict-first' };
+  recordPollSkip(first, deps, 'no_pending_history', '待命。');
+  for (let i = 0; i < 60; i += 1) {
+    recordPollSkip({ chatId: `skip-report-evict-${i}` }, deps, 'no_pending_history', '待命。');
+  }
+  assert.ok(__pollWaitByChatForTest.size <= 50, `实际 ${__pollWaitByChatForTest.size}`);
+  assert.equal(getPollWaitStatus(first), null, '最早的聊天先被淘汰');
 });
 
 test('dry-run 的 generation_started 不计入忙碌（宿主只发 STARTED 不发 ENDED）', async () => {

--- a/tests/poll_skip_report.test.mjs
+++ b/tests/poll_skip_report.test.mjs
@@ -1,0 +1,140 @@
+// 轮询跳过原因显形：自动独有的静默早退必须在面板留下原因，
+// 否则“自动不可用、手动可用”时无从定位。只在原因变化时写一次。
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as state from '../scripts/state.js';
+import {
+  __pollSkipReportForTest,
+  poll,
+  recordPollSkip,
+  runTracker,
+  installHostRunWatchers,
+  __hostRunStateForTest,
+  __mvuGateStateForTest,
+} from '../scripts/tracker.js';
+
+function makeFakeEventBus() {
+  const handlers = new Map();
+  return {
+    on(name, handler) {
+      if (!handlers.has(name)) handlers.set(name, []);
+      handlers.get(name).push(handler);
+    },
+    emit(name, ...args) {
+      (handlers.get(name) || []).forEach((handler) => handler(...args));
+    },
+  };
+}
+
+function resetGates(ctx) {
+  const run = __hostRunStateForTest;
+  run.listenersInstalled = false;
+  run.generationDepth = 0;
+  run.generationBusySince = 0;
+  run.mutSeq = 0;
+  run.ctxRef = null;
+  const gate = __mvuGateStateForTest;
+  gate.lastEndedKey = '';
+  gate.lastEndedContentKey = '';
+  gate.lastEndedAt = 0;
+  gate.pendingKey = '';
+  gate.pendingContentKey = '';
+  gate.pendingSince = 0;
+  gate.generateInFlight = 0;
+  gate.lastGenerateStartedAt = 0;
+  gate.sawGenerateThisRound = false;
+  gate.everSawMvuSignal = false;
+  __pollSkipReportForTest.chatKey = '';
+  __pollSkipReportForTest.reason = '';
+  delete globalThis.Mvu;
+  delete globalThis.document;
+  if (ctx?.eventSource) installHostRunWatchers(ctx);
+}
+
+function makeCtx(chatId = 'skip-report-chat') {
+  const ctx = {
+    chatId,
+    chat: [{ is_user: false, name: 'Alice', mes: 'previous reply', swipe_id: 0 }],
+    extensionSettings: {},
+    saveSettingsDebounced() {},
+    eventSource: makeFakeEventBus(),
+    eventTypes: {
+      GENERATION_STARTED: 'generation_started',
+      GENERATION_STOPPED: 'generation_stopped',
+      GENERATION_ENDED: 'generation_ended',
+      MESSAGE_EDITED: 'message_edited',
+      MESSAGE_SWIPED: 'message_swiped',
+      MESSAGE_UPDATED: 'message_updated',
+    },
+  };
+  globalThis.SillyTavern = { getContext: () => ctx };
+  const settings = state.getSettings(ctx);
+  settings.enabled = true;
+  settings.triggerTiming = 'after_ai';
+  state.getChatState(ctx, settings).characters['艾拉'] = {
+    name: '艾拉', initialized: true, profile: { base: {} },
+  };
+  resetGates(ctx);
+  return { ctx, settings };
+}
+
+function makeDeps() {
+  const renders = [];
+  return { deps: { renderStatusPanel() { renders.push(1); }, updateMainFlowPrompt() {} }, renders };
+}
+
+test('recordPollSkip 首报写入面板，同原因重复不再写', () => {
+  const { ctx, settings } = makeCtx();
+  const { deps, renders } = makeDeps();
+  const chatState = state.getChatState(ctx, settings);
+
+  const first = recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  assert.deepEqual(first, { skipped: true, reason: 'no_pending_history' });
+  assert.equal(chatState.lastRawResult.message, '没有新的可追踪内容，自动追踪待命中。');
+  assert.equal(renders.length, 1);
+
+  const second = recordPollSkip(ctx, chatState, deps, 'no_pending_history', '没有新的可追踪内容，自动追踪待命中。');
+  assert.deepEqual(second, { skipped: true, reason: 'no_pending_history' });
+  assert.equal(renders.length, 1, '同聊天同原因不重复写');
+});
+
+test('recordPollSkip 原因变化或换聊天时重新写', () => {
+  const { ctx, settings } = makeCtx();
+  const { deps, renders } = makeDeps();
+  const chatState = state.getChatState(ctx, settings);
+
+  recordPollSkip(ctx, chatState, deps, 'message_not_settled', '等待 AI 正文稳定后再追踪。');
+  assert.equal(renders.length, 1);
+  recordPollSkip(ctx, chatState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
+  assert.equal(renders.length, 2);
+  assert.equal(chatState.lastRawResult.message, '宿主仍在生成中，自动追踪等待中。');
+
+  const other = makeCtx('skip-report-other-chat');
+  const otherState = state.getChatState(other.ctx, other.settings);
+  recordPollSkip(other.ctx, otherState, deps, 'host_generation_in_flight', '宿主仍在生成中，自动追踪等待中。');
+  assert.equal(renders.length, 3, '换聊天重新写');
+});
+
+test('runTracker 宿主忙碌时面板留下原因', async () => {
+  const { ctx } = makeCtx();
+  const { deps } = makeDeps();
+  ctx.eventSource.emit('generation_started');
+  assert.equal(__hostRunStateForTest.generationDepth, 1);
+
+  const outcome = await runTracker(ctx, deps, 'poll');
+  assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
+  const chatState = state.getChatState(ctx, state.getSettings(ctx));
+  assert.equal(chatState.lastRawResult.message, '宿主仍在生成中，自动追踪等待中。');
+});
+
+test('poll 未启用时面板留下原因', async () => {
+  const { ctx, settings } = makeCtx();
+  settings.enabled = false;
+  const { deps } = makeDeps();
+
+  const outcome = await poll(ctx, deps);
+  assert.deepEqual(outcome, { skipped: true, reason: 'disabled' });
+  const chatState = state.getChatState(ctx, state.getSettings(ctx));
+  assert.equal(chatState.lastRawResult.message, '自动追踪未启用（在设置中开启后生效）。');
+});

--- a/tests/poll_skip_report.test.mjs
+++ b/tests/poll_skip_report.test.mjs
@@ -116,7 +116,7 @@ test('recordPollSkip 原因变化或换聊天时重新写', () => {
   assert.equal(renders.length, 3, '换聊天重新写');
 });
 
-test('runTracker 宿主忙碌时面板留下原因', async () => {
+test('runTracker 宿主忙碌时面板留下原因（事件计数一路）', async () => {
   const { ctx } = makeCtx();
   const { deps } = makeDeps();
   ctx.eventSource.emit('generation_started');
@@ -125,7 +125,21 @@ test('runTracker 宿主忙碌时面板留下原因', async () => {
   const outcome = await runTracker(ctx, deps, 'poll');
   assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
   const chatState = state.getChatState(ctx, state.getSettings(ctx));
-  assert.equal(chatState.lastRawResult.message, '宿主仍在生成中，自动追踪等待中。');
+  assert.equal(chatState.lastRawResult.message, '宿主生成事件未闭合（1 层），自动追踪等待中。');
+});
+
+test('runTracker 宿主忙碌时面板留下原因（停止按钮旗标一路）', async () => {
+  const { ctx } = makeCtx();
+  const { deps } = makeDeps();
+  globalThis.document = { body: { dataset: { generating: 'true' } } };
+  try {
+    const outcome = await runTracker(ctx, deps, 'poll');
+    assert.deepEqual(outcome, { skipped: true, reason: 'host_generation_in_flight' });
+    const chatState = state.getChatState(ctx, state.getSettings(ctx));
+    assert.equal(chatState.lastRawResult.message, '宿主仍在生成中（停止按钮未释放），自动追踪等待中。');
+  } finally {
+    delete globalThis.document;
+  }
 });
 
 test('poll 未启用时面板留下原因', async () => {


### PR DESCRIPTION
## 背景

有使用者回報：在酒館裡游玩**沒有 MVU 腳本**的角色卡時，自動追蹤完全不可用、只能手動追蹤；進一步回報指出追蹤「卡在了正文生成階段」。手動可用證明請求鏈本身是通的，問題出在自動獨有的輪詢門控上。排查後確認是三個疊加的原因（詳見方案），其中主因已由回報者更新 fork 版後**實測確認修復**。

## 方案

1. **MVU 門控改以「全局在場」為準**。`mvu_settings` 是全局持久、跨卡跨聊天共享且無人清理的，停用 MVU 或換到無 MVU 的卡後依然殘留；舊碼只憑它就認定有 MVU，每輪白等寬限期。而 MVU 只在「優先實例」上把 `Mvu` 掛到 `window.parent`，設定會殘留、全局不會。改為要求 `mvuPresent`，並給 `generateActive` 兜底加上同一前提（它本就只為舊版 MVU 準備）；`everSawMvuSignal` 在全局不在場時一併清除（生產路徑上它從不清零）。
2. **輪詢跳過原因顯形（作者 review 後改為獨立暫態欄位）**。自動獨有的早退分支原本全程靜默，面板停在舊結果上，無從定位。待命原因放在模組級 Map（按聊天隔離，保留最近 50 個），天然暫態：不進 `chatState`、不持久化、不進快照，更不改寫 `lastRawResult`／`lastOperationLogs`；面板另起一行展示，去重鍵為同聊天＋同原因＋同文案＋同來源（忙碌來源切換、層數變化都會刷新）。
3. **忙碌原因拆到信號級**。`host_generation_in_flight` 有兩路並聯信號：停止按鈕旗標（無自愈）與生成事件計數（600 秒自愈），面板分別顯示，回報時一句話即可定位。
4. **dry-run 的 `GENERATION_STARTED` 不計入忙碌深度（主因）**。兩家宿主每次 `Generate()`——含 dry-run 的 token 計數——都會發 `GENERATION_STARTED`（ST `script.js:4240`、TT `script.js:5351`，dry-run 標誌在事件參數最後一位）；但干完活清場靠 `hideStopButton()`，它有 NOOP 守衛，按鈕從沒顯示過就什麼都不做（ST `3473-3479`、TT `4414-4420`）。於是每次 token 計數都漏 +1 到 `generationDepth`，只能靠 600 秒自愈；期间自動追蹤被擋、手動不受影響。回報者的面板正好顯示「生成事件未閉合（1 層）」而停止按鈕已釋放，與此機制完全吻合。

## 具體改動

- `scripts/tracker.js` `shouldWaitForMvuExtraAnalysis`：提前計算 `mvu`／`mvuPresent`；不在場時清 `everSawMvuSignal`；只憑設定的武裝與 `generateActive` 兜底均加 `mvuPresent` 前提。
- `scripts/tracker.js` `markHostGenerationStart`：事件參數最後一位 `=== true`（兩家 dry-run 簽名一致）時不計數，其它一律照計。
- `scripts/tracker.js` 新增 `getHostBusyDetail`（`isHostGenerationBusy` 改為委託它，行為不變）與 `recordPollSkip`（暫態＋變化才渲染，零持久化；Agent 等待兩路亦改走它；真实开跑／改寫結果／靜默吸收處一律清除舊待命）；`runTracker` 的靜默早退分支（宿主忙碌、未穩定、無新歷史、MVU 等待、失敗重試鎖）與 `poll()` 未啟用分支改走它。
- `tests/mvu_gate.test.mjs`：翻轉「無 `Mvu` 全局＋特徵請求在飛 → 等待」的舊用例；新增設定殘留、舊版 MVU 兜底、粘性清除、`window.parent.Mvu`、非物件 `Mvu` 等用例。
- `tests/poll_skip_report.test.mjs`（新增）：暫態不動真實結果與執行日誌、文案／來源變化刷新、兩路忙碌訊息、未啟用提示、早退改寫結果時舊待命清除、Map 有界、dry-run 不計數／真生成照計。
- `index.js`／`settings.html`：面板「最新工具調用」上方新增待命行（`textContent` 寫入），缺元素時跳過。

## 相容性

- **新版 MVU**：權威訊號照舊；**舊版 MVU**（全局在場、無 `isDuringExtraAnalysis`）：兜底路徑原樣保留。
- 「舊版 MVU 是否也掛全局」已回溯查證：MVU 倉（`MagicalAstrogy/MagVarUpdate`，378 提交）完整歷史顯示，全局掛載（2025-08-10，`1845ce6`，當時無條件呼叫）早於「額外模型解析」模式（2025-10-08）約兩個月——凡是有該模式的版本都會掛全局，更早版本門控本就不會武裝。
- 真生成的忙碌計數邏輯未動；`isHostGenerationBusy` 對外行為不變；待命行是純記憶體暫態，重載即空，不增加任何持久化開銷。
- 不寫 README、不改版本號、不動 Changelog。

## 測試

- `tests/mvu_gate.test.mjs` 34/34、`tests/poll_skip_report.test.mjs` 10/10、`tests/host_generation_busy.test.mjs` 相關全過。
- 全套 `node --test --test-timeout=30000 "tests/**/*.test.mjs"`：**436/436 綠**（滿載下一次全綠；舊的時間敏感抖動用例本次未再現）。
- 新用例確實攔得住回歸：新版測試對舊碼跑得 30 pass / 4 fail，紅的正是本次翻轉與新增項。
- 另派子代理獨立審查（對抗性找反例、酒館助手／MVU 生命週期、PR 逐條事實核對），意見均已落實；回報者更新 fork 版後實測確認自動追蹤恢復。作者對 #12 的 review 意見（待命狀態改獨立暫態欄位、訊息／來源納入去重）已按此改完，含 review 追加指出的早退漏清與 Map 有界。

